### PR TITLE
feat: add HTTP proxy support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -21,7 +21,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._extensionPath = extensionPath;
         this._settings = settings;
         this._openPreferences = openPreferences;
-        this._session = new Soup.Session();
+        this._session = this._createSession();
 
         // Create box for panel button
         this._box = new St.BoxLayout({
@@ -74,6 +74,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._updateDisplayMode();
             } else if (key === 'show-icon') {
                 this._updateIconVisibility();
+            } else if (key === 'proxy-url') {
+                this._recreateSession();
             }
         });
 
@@ -106,6 +108,26 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         } else {
             this._icon.hide();
         }
+    }
+
+    _createSession() {
+        const session = new Soup.Session();
+        const proxyUrl = this._settings.get_string('proxy-url');
+
+        if (proxyUrl && proxyUrl.trim() !== '') {
+            const proxyResolver = Gio.SimpleProxyResolver.new(proxyUrl.trim(), null);
+            session.set_proxy_resolver(proxyResolver);
+        }
+
+        return session;
+    }
+
+    _recreateSession() {
+        if (this._session) {
+            this._session.abort();
+        }
+        this._session = this._createSession();
+        this._refreshUsage();
     }
 
     _createMenu() {

--- a/prefs.js
+++ b/prefs.js
@@ -82,5 +82,32 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             Gio.SettingsBindFlags.DEFAULT
         );
         displayGroup.add(showIconRow);
+
+        // Network group
+        const networkGroup = new Adw.PreferencesGroup({
+            title: 'Network',
+            description: 'Configure network settings',
+        });
+        page.add(networkGroup);
+
+        // Proxy setting
+        const proxyRow = new Adw.EntryRow({
+            title: 'Proxy URL',
+            show_apply_button: true,
+        });
+        proxyRow.set_text(settings.get_string('proxy-url'));
+        proxyRow.connect('apply', () => {
+            settings.set_string('proxy-url', proxyRow.get_text());
+        });
+        networkGroup.add(proxyRow);
+
+        const proxyHint = new Gtk.Label({
+            label: 'Example: http://localhost:11809 (leave empty for no proxy)',
+            xalign: 0,
+            css_classes: ['dim-label', 'caption'],
+            margin_start: 12,
+            margin_top: 4,
+        });
+        networkGroup.add(proxyHint);
     }
 }

--- a/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-usage.gschema.xml
@@ -16,5 +16,10 @@
       <summary>Show icon</summary>
       <description>Whether to show the Claude icon in the top bar</description>
     </key>
+    <key name="proxy-url" type="s">
+      <default>''</default>
+      <summary>Proxy URL</summary>
+      <description>HTTP proxy URL (e.g., http://localhost:11809). Leave empty to use no proxy.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
- Add proxy-url setting to configure HTTP proxy for API requests
- Add Network section in preferences UI with Proxy URL field

by CC