### PR TITLE
Fix for gnome 46

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The extension is distributed on *extensions.gnome.org* here : [link](https://ext
 
 ```bash
 git clone https://github.com/Haletran/claude-usage-extension
-cp -r claude-usage-extension ~/.local/share/gnome-shell/extensions/claude-usage@haletran.com 
-cd ~/.local/share/gnome-shell/extensions/claude-usage@haletran.com/schemas                                                                                                                                      
+cp -r claude-usage-extension ~/.local/share/gnome-shell/extensions/claude-code-usage@haletran.com 
+cd ~/.local/share/gnome-shell/extensions/claude-code-usage@haletran.com/schemas                                                                                                                                        
 glib-compile-schemas .
 ## Restart Gnome Shell with Alt + F2 type r or logout
 ## Then enable the extension

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Claude Code Usage",
   "description": "Display Claude Code usage in the top panel. This extension uses anthropic.com services. This extension is not affiliated, funded, or in any way associated with Claude.",
   "uuid": "claude-code-usage@haletran.com",
-  "shell-version": ["48", "49"],
+  "shell-version": ["46", "47", "48", "49"],
   "url": "https://github.com/Haletran/claude-usage-extension",
   "settings-schema": "org.gnome.shell.extensions.claude-code-usage",
   "donations": {

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schemalist gettext-domain="claude-usage">
-  <schema id="org.gnome.shell.extensions.claude-usage" path="/org/gnome/shell/extensions/claude-usage/">
+<schemalist gettext-domain="claude-code-usage">
+  <schema id="org.gnome.shell.extensions.claude-code-usage" path="/org/gnome/shell/extensions/claude-code-usage/">
     <key name="refresh-interval" type="i">
       <default>300</default>
       <summary>Refresh interval</summary>


### PR DESCRIPTION
I can confirm that this extension is working on Gnome 46 as well, tested on Ubuntu 24.04.3 LTS

Not sure if it is possible to change the `uuid` of the extension, so I took the liberty to update the extension schemas so they match the uuid