### PR TITLE
Make icon white

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -133,7 +133,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         if (style === 'monochrome' && !hasEffect) {
             this._icon.add_effect(new Clutter.DesaturateEffect({factor: 1.0, name: desatName}));
             const brightnessEffect = new Clutter.BrightnessContrastEffect({name: brightName});
-            brightnessEffect.set_brightness_full(0.6, 0.6, 0.6);
+            brightnessEffect.set_brightness_full(1, 1, 1);
             this._icon.add_effect(brightnessEffect);
         } else if (style !== 'monochrome' && hasEffect) {
             this._icon.remove_effect_by_name(desatName);


### PR DESCRIPTION
Thanks for fixing https://github.com/Haletran/claude-usage-extension/issues/5

What do you think if we will have monochrome icon a little brighter?

All GNOME icons are strictly white (with dark-grey for disabled parts), so they avoid gradients. I think white icon will be closer to GNOME guidelines.

Before
<img width="508" height="126" alt="Снимок экрана от 2026-02-13 18-23-05" src="https://github.com/user-attachments/assets/9f40dbbb-13b3-4fa2-bfc8-5388d7ff0ed9" />

After
<img width="502" height="86" alt="Снимок экрана от 2026-02-13 18-30-53" src="https://github.com/user-attachments/assets/7c4d7e33-4597-4835-99f5-fa3577062837" />
