### PR TITLE
Feat/expired tokens multi account theme

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -108,6 +108,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._updateExpiredVisibility();
             } else if (key === 'extra-accounts' || key === 'account-labels') {
                 this._rebuildAccounts();
+            } else if (key === 'panel-account-mode' || key === 'pinned-accounts') {
+                this._updatePanelFromAccounts();
             }
         });
 
@@ -608,41 +610,61 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     // --- Panel UI ---
 
     _updatePanelFromAccounts() {
-        // Find the account with highest 5-hour utilization among non-expired accounts with data
-        let worstAccount = null;
-        let worstUsage = -1;
+        // Single account: simple display, no mode dispatch
+        if (this._accounts.length <= 1) {
+            this._updatePanelSingleAccount('highest');
+        } else {
+            const mode = this._settings.get_string('panel-account-mode');
+            if (mode === 'pinned')
+                this._updatePanelPinned();
+            else
+                this._updatePanelSingleAccount(mode);
+        }
 
+        // Global expired state
+        const allExpired = this._accounts.length > 0 &&
+            this._accounts.every(a => a.isTokenExpired);
+        this._setGlobalExpiredState(allExpired);
+    }
+
+    _updatePanelSingleAccount(mode) {
+        const isLowest = mode === 'lowest';
+        let selectedAccount = null;
+        let selectedUsage = isLowest ? Infinity : -1;
+
+        // First pass: non-expired accounts with data
         for (const account of this._accounts) {
             if (account.isTokenExpired || !account.cachedData)
                 continue;
             const usage = account.cachedData.five_hour?.utilization ?? 0;
-            if (usage > worstUsage) {
-                worstUsage = usage;
-                worstAccount = account;
+            if (isLowest ? usage < selectedUsage : usage > selectedUsage) {
+                selectedUsage = usage;
+                selectedAccount = account;
             }
         }
 
-        // If all expired/no data, try cached data from expired accounts
-        if (!worstAccount) {
+        // Fallback: expired accounts with cached data
+        if (!selectedAccount) {
+            selectedUsage = isLowest ? Infinity : -1;
             for (const account of this._accounts) {
                 if (!account.cachedData)
                     continue;
                 const usage = account.cachedData.five_hour?.utilization ?? 0;
-                if (usage > worstUsage) {
-                    worstUsage = usage;
-                    worstAccount = account;
+                if (isLowest ? usage < selectedUsage : usage > selectedUsage) {
+                    selectedUsage = usage;
+                    selectedAccount = account;
                 }
             }
         }
 
-        if (worstAccount) {
-            const usage = worstUsage;
-            const suffix = worstAccount.isTokenExpired ? ' (cached)' : '';
+        if (selectedAccount) {
+            const usage = selectedUsage;
+            const suffix = selectedAccount.isTokenExpired ? ' (cached)' : '';
 
             if (this._accounts.length === 1) {
                 this._label.set_text(`${Math.round(usage)}%${suffix}`);
             } else {
-                this._label.set_text(`${worstAccount.label}: ${Math.round(usage)}%${suffix}`);
+                this._label.set_text(`${selectedAccount.label}: ${Math.round(usage)}%${suffix}`);
             }
 
             this._updatePanelProgressBar(usage);
@@ -650,11 +672,53 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             this._label.set_text('...');
             this._updatePanelProgressBar(0);
         }
+    }
 
-        // Global expired state
-        const allExpired = this._accounts.length > 0 &&
-            this._accounts.every(a => a.isTokenExpired);
-        this._setGlobalExpiredState(allExpired);
+    _updatePanelPinned() {
+        const pinnedPaths = this._settings.get_strv('pinned-accounts');
+
+        // Clean up stale pinned paths
+        const validPaths = pinnedPaths.filter(p =>
+            this._accounts.some(a => a.configDir === p)
+        );
+        if (validPaths.length !== pinnedPaths.length)
+            this._settings.set_strv('pinned-accounts', validPaths);
+
+        // Filter accounts to pinned ones
+        const pinnedAccounts = this._accounts.filter(a =>
+            validPaths.includes(a.configDir)
+        );
+
+        if (pinnedAccounts.length === 0) {
+            this._label.set_text('No pins');
+            this._updatePanelProgressBar(0);
+            return;
+        }
+
+        // Build label: "work: 45% | personal: 20%"
+        const parts = [];
+        let maxUsage = 0;
+
+        for (const account of pinnedAccounts) {
+            const data = account.cachedData;
+            if (!data) {
+                if (account.isTokenExpired)
+                    parts.push(`${account.label}: expired`);
+                else
+                    parts.push(`${account.label}: ...`);
+                continue;
+            }
+
+            const usage = data.five_hour?.utilization ?? 0;
+            if (usage > maxUsage)
+                maxUsage = usage;
+
+            const suffix = account.isTokenExpired ? '*' : '';
+            parts.push(`${account.label}: ${Math.round(usage)}%${suffix}`);
+        }
+
+        this._label.set_text(parts.join(' | '));
+        this._updatePanelProgressBar(maxUsage);
     }
 
     _setAccountExpired(account, expired) {

--- a/extension.js
+++ b/extension.js
@@ -56,6 +56,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._session = this._createSession();
         this._accounts = [];
         this._allTokensExpired = false;
+        this._pinnedPanelWidgets = null;
 
         this._box = new St.BoxLayout({
             style_class: 'panel-status-menu-box',
@@ -89,7 +90,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
         this.add_child(this._box);
 
-        this._updateDisplayMode();
+        this._applyDisplayMode();
         this._updateIconVisibility();
         this._updateIconStyle();
 
@@ -118,6 +119,13 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     _updateDisplayMode() {
+        this._applyDisplayMode();
+        // Re-render panel if accounts are loaded (handles pinned mode rebuild)
+        if (this._accounts && this._accounts.length > 0)
+            this._updatePanelFromAccounts();
+    }
+
+    _applyDisplayMode() {
         const mode = this._settings.get_string('display-mode');
         if (mode === 'bar') {
             this._panelProgressBg.show();
@@ -627,7 +635,20 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._setGlobalExpiredState(allExpired);
     }
 
+    _clearPinnedPanelWidgets() {
+        if (this._pinnedPanelWidgets) {
+            for (const widget of this._pinnedPanelWidgets) {
+                this._box.remove_child(widget);
+                widget.destroy();
+            }
+            this._pinnedPanelWidgets = null;
+        }
+    }
+
     _updatePanelSingleAccount(mode) {
+        this._clearPinnedPanelWidgets();
+        this._applyDisplayMode();
+
         const isLowest = mode === 'lowest';
         let selectedAccount = null;
         let selectedUsage = isLowest ? Infinity : -1;
@@ -675,50 +696,99 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     _updatePanelPinned() {
-        const pinnedPaths = this._settings.get_strv('pinned-accounts');
+        // Hide default single-account widgets
+        this._label.hide();
+        this._panelProgressBg.hide();
 
-        // Clean up stale pinned paths
+        // Clean previous pinned widgets
+        this._clearPinnedPanelWidgets();
+
+        const pinnedPaths = this._settings.get_strv('pinned-accounts');
         const validPaths = pinnedPaths.filter(p =>
             this._accounts.some(a => a.configDir === p)
         );
         if (validPaths.length !== pinnedPaths.length)
             this._settings.set_strv('pinned-accounts', validPaths);
 
-        // Filter accounts to pinned ones
         const pinnedAccounts = this._accounts.filter(a =>
             validPaths.includes(a.configDir)
         );
 
         if (pinnedAccounts.length === 0) {
+            this._label.show();
             this._label.set_text('No pins');
-            this._updatePanelProgressBar(0);
+            this._label.set_style('margin-left: 0;');
             return;
         }
 
-        // Build label: "work: 45% | personal: 20%"
-        const parts = [];
-        let maxUsage = 0;
+        const displayMode = this._settings.get_string('display-mode');
+        this._pinnedPanelWidgets = [];
 
-        for (const account of pinnedAccounts) {
-            const data = account.cachedData;
-            if (!data) {
-                if (account.isTokenExpired)
-                    parts.push(`${account.label}: expired`);
-                else
-                    parts.push(`${account.label}: ...`);
-                continue;
+        pinnedAccounts.forEach((account, index) => {
+            // Separator between accounts
+            if (index > 0) {
+                const sep = new St.Label({
+                    text: '|',
+                    y_align: Clutter.ActorAlign.CENTER,
+                    style_class: 'claude-usage-label',
+                });
+                this._box.add_child(sep);
+                this._pinnedPanelWidgets.push(sep);
             }
 
-            const usage = data.five_hour?.utilization ?? 0;
-            if (usage > maxUsage)
-                maxUsage = usage;
-
+            const data = account.cachedData;
+            const usage = data?.five_hour?.utilization ?? 0;
             const suffix = account.isTokenExpired ? '*' : '';
-            parts.push(`${account.label}: ${Math.round(usage)}%${suffix}`);
-        }
 
-        this._label.set_text(parts.join(' | '));
-        this._updatePanelProgressBar(maxUsage);
+            // Bar and both modes: show name label + progress bar
+            if (displayMode === 'bar' || displayMode === 'both') {
+                const nameLabel = new St.Label({
+                    text: account.label,
+                    y_align: Clutter.ActorAlign.CENTER,
+                    style_class: 'claude-usage-label',
+                });
+                this._box.add_child(nameLabel);
+                this._pinnedPanelWidgets.push(nameLabel);
+
+                const bg = new St.Widget({
+                    style_class: 'claude-panel-progress-bg',
+                    y_align: Clutter.ActorAlign.CENTER,
+                });
+                const bar = new St.Widget({
+                    style_class: 'claude-panel-progress-bar',
+                });
+                bg.add_child(bar);
+                this._box.add_child(bg);
+                this._pinnedPanelWidgets.push(bg);
+
+                const maxWidth = 50;
+                const width = Math.round((Math.min(100, Math.max(0, usage)) / 100) * maxWidth);
+                bar.set_width(width);
+            }
+
+            // Text and both modes: show percentage text
+            if (displayMode === 'both' || displayMode === 'text') {
+                let textContent;
+                if (!data) {
+                    textContent = account.isTokenExpired
+                        ? `${account.label}: exp` : `${account.label}: ...`;
+                } else if (displayMode === 'text') {
+                    textContent = `${account.label}: ${Math.round(usage)}%${suffix}`;
+                } else {
+                    textContent = `${Math.round(usage)}%${suffix}`;
+                }
+
+                const textLabel = new St.Label({
+                    text: textContent,
+                    y_align: Clutter.ActorAlign.CENTER,
+                    style_class: 'claude-usage-label',
+                });
+                if (displayMode === 'both')
+                    textLabel.set_style('margin-left: 6px;');
+                this._box.add_child(textLabel);
+                this._pinnedPanelWidgets.push(textLabel);
+            }
+        });
     }
 
     _setAccountExpired(account, expired) {
@@ -821,6 +891,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
     destroy() {
         this._stopTimer();
+        this._clearPinnedPanelWidgets();
         for (const account of this._accounts) {
             account.destroy();
         }

--- a/extension.js
+++ b/extension.js
@@ -22,6 +22,11 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._settings = settings;
         this._openPreferences = openPreferences;
         this._session = this._createSession();
+        this._isTokenExpired = false;
+        this._cachedData = null;
+        this._credentialsMonitor = null;
+        this._credentialsMonitorId = null;
+        this._debounceTimerId = null;
 
         this._box = new St.BoxLayout({
             style_class: 'panel-status-menu-box',
@@ -72,11 +77,14 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._recreateSession();
             } else if (key === 'icon-style') {
                 this._updateIconStyle();
+            } else if (key === 'hide-on-expired') {
+                this._updateExpiredVisibility();
             }
         });
 
         this._refreshUsage();
         this._startTimer();
+        this._startCredentialsMonitor();
     }
 
     _updateDisplayMode() {
@@ -259,6 +267,89 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._startTimer();
     }
 
+    _startCredentialsMonitor() {
+        try {
+            const configDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
+                GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
+            const credentialsPath = GLib.build_filenamev([
+                configDir,
+                '.credentials.json',
+            ]);
+            const file = Gio.File.new_for_path(credentialsPath);
+            this._credentialsMonitor = file.monitor_file(Gio.FileMonitorFlags.NONE, null);
+            this._credentialsMonitorId = this._credentialsMonitor.connect('changed', (monitor, changedFile, otherFile, eventType) => {
+                if (eventType === Gio.FileMonitorEvent.CHANGED ||
+                    eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+                    this._debouncedRefresh();
+                }
+            });
+        } catch (e) {
+            console.error('Claude Usage: Failed to start credentials monitor:', e.message);
+        }
+    }
+
+    _debouncedRefresh() {
+        if (this._debounceTimerId) {
+            GLib.source_remove(this._debounceTimerId);
+            this._debounceTimerId = null;
+        }
+        this._debounceTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            this._debounceTimerId = null;
+            this._refreshUsage();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _stopCredentialsMonitor() {
+        if (this._debounceTimerId) {
+            GLib.source_remove(this._debounceTimerId);
+            this._debounceTimerId = null;
+        }
+        if (this._credentialsMonitorId && this._credentialsMonitor) {
+            this._credentialsMonitor.disconnect(this._credentialsMonitorId);
+            this._credentialsMonitorId = null;
+        }
+        if (this._credentialsMonitor) {
+            this._credentialsMonitor.cancel();
+            this._credentialsMonitor = null;
+        }
+    }
+
+    _setExpiredState(expired) {
+        this._isTokenExpired = expired;
+        const effectName = 'expired-desaturate';
+
+        if (expired) {
+            if (!this._icon.get_effect(effectName)) {
+                this._icon.add_effect(new Clutter.DesaturateEffect({factor: 1.0, name: effectName}));
+            }
+            this._icon.set_opacity(128);
+
+            if (this._cachedData) {
+                const fiveHour = this._cachedData.five_hour?.utilization ?? 0;
+                this._label.set_text(`${Math.round(fiveHour)}% (cached)`);
+                this._fiveHourPercent.set_text(`${fiveHour.toFixed(1)}% (cached)`);
+            } else {
+                this._label.set_text('Expired');
+                this._fiveHourPercent.set_text('Token expired');
+            }
+
+            this._updateExpiredVisibility();
+        } else {
+            this._icon.remove_effect_by_name(effectName);
+            this._icon.set_opacity(255);
+            this.show();
+        }
+    }
+
+    _updateExpiredVisibility() {
+        if (this._isTokenExpired && this._settings.get_boolean('hide-on-expired')) {
+            this.hide();
+        } else {
+            this.show();
+        }
+    }
+
     _refreshUsage() {
         const configDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
             GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
@@ -305,6 +396,11 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 try {
                     const bytes = session.send_and_read_finish(result);
 
+                    if (message.status_code === 401) {
+                        this._setExpiredState(true);
+                        return;
+                    }
+
                     if (message.status_code !== 200) {
                         this._label.set_text('Error');
                         this._fiveHourPercent.set_text(`HTTP ${message.status_code}`);
@@ -314,6 +410,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                     const decoder = new TextDecoder('utf-8');
                     const data = JSON.parse(decoder.decode(bytes.get_data()));
 
+                    this._cachedData = data;
+                    this._setExpiredState(false);
                     this._updateDisplay(data);
                 } catch (e) {
                     console.error('Claude Usage: Failed to fetch usage:', e.message);
@@ -404,6 +502,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     destroy() {
+        this._stopCredentialsMonitor();
+        this._cachedData = null;
         this._stopTimer();
         if (this._session) {
             this._session.abort();

--- a/extension.js
+++ b/extension.js
@@ -13,6 +13,38 @@ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/ex
 
 const API_URL = 'https://api.anthropic.com/api/oauth/usage';
 
+class AccountState {
+    constructor(id, label, configDir) {
+        this.id = id;
+        this.label = label;
+        this.configDir = configDir;
+        this.credentialsPath = GLib.build_filenamev([configDir, '.credentials.json']);
+        this.cachedData = null;
+        this.isTokenExpired = false;
+        this.fileMonitor = null;
+        this.fileMonitorSignalId = null;
+        this.debounceTimerId = null;
+        this.menuWidgets = null;
+    }
+
+    destroy() {
+        if (this.debounceTimerId) {
+            GLib.source_remove(this.debounceTimerId);
+            this.debounceTimerId = null;
+        }
+        if (this.fileMonitorSignalId && this.fileMonitor) {
+            this.fileMonitor.disconnect(this.fileMonitorSignalId);
+            this.fileMonitorSignalId = null;
+        }
+        if (this.fileMonitor) {
+            this.fileMonitor.cancel();
+            this.fileMonitor = null;
+        }
+        this.cachedData = null;
+        this.menuWidgets = null;
+    }
+}
+
 const ClaudeUsageIndicator = GObject.registerClass(
 class ClaudeUsageIndicator extends PanelMenu.Button {
     _init(extensionPath, settings, openPreferences) {
@@ -22,11 +54,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._settings = settings;
         this._openPreferences = openPreferences;
         this._session = this._createSession();
-        this._isTokenExpired = false;
-        this._cachedData = null;
-        this._credentialsMonitor = null;
-        this._credentialsMonitorId = null;
-        this._debounceTimerId = null;
+        this._accounts = [];
+        this._allTokensExpired = false;
 
         this._box = new St.BoxLayout({
             style_class: 'panel-status-menu-box',
@@ -60,8 +89,6 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
         this.add_child(this._box);
 
-        this._createMenu();
-
         this._updateDisplayMode();
         this._updateIconVisibility();
         this._updateIconStyle();
@@ -79,12 +106,13 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._updateIconStyle();
             } else if (key === 'hide-on-expired') {
                 this._updateExpiredVisibility();
+            } else if (key === 'extra-accounts' || key === 'account-labels') {
+                this._rebuildAccounts();
             }
         });
 
-        this._refreshUsage();
+        this._rebuildAccounts();
         this._startTimer();
-        this._startCredentialsMonitor();
     }
 
     _updateDisplayMode() {
@@ -130,8 +158,9 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             this._session.abort();
         }
         this._session = this._createSession();
-        this._refreshUsage();
-	}
+        this._refreshAllAccounts();
+    }
+
     _updateIconStyle() {
         const style = this._settings.get_string('icon-style');
         const desatName = 'monochrome-desaturate';
@@ -149,99 +178,151 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         }
     }
 
-    _createMenu() {
-        const fiveHourBox = new St.BoxLayout({
-            style_class: 'claude-usage-section',
-            vertical: true,
-        });
-        const fiveHourHeader = new St.BoxLayout({ vertical: false });
-        const fiveHourLabel = new St.Label({
-            text: '5-Hour Usage',
-            style_class: 'claude-section-title',
-        });
-        fiveHourHeader.add_child(fiveHourLabel);
-        this._fiveHourPercent = new St.Label({
-            text: '...',
-            style_class: 'claude-percent-label',
-            x_expand: true,
-            x_align: Clutter.ActorAlign.END,
-        });
-        fiveHourHeader.add_child(this._fiveHourPercent);
-        fiveHourBox.add_child(fiveHourHeader);
+    // --- Account discovery ---
 
-        const fiveHourProgressBg = new St.Widget({
-            style_class: 'claude-progress-bg',
-        });
-        this._fiveHourProgressBar = new St.Widget({
-            style_class: 'claude-progress-bar usage-low',
-        });
-        fiveHourProgressBg.add_child(this._fiveHourProgressBar);
-        fiveHourBox.add_child(fiveHourProgressBg);
+    _discoverAccounts() {
+        const seen = new Set();
+        const results = [];
 
-        this._fiveHourResetLabel = new St.Label({
-            text: 'Resets: ...',
-            style_class: 'claude-reset-label',
-        });
-        fiveHourBox.add_child(this._fiveHourResetLabel);
+        // Default account
+        const defaultDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
+            GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
+        const defaultResolved = Gio.File.new_for_path(defaultDir).get_path();
+        seen.add(defaultResolved);
+        results.push({id: 'default', label: 'default', configDir: defaultResolved});
 
-        const fiveHourItem = new PopupMenu.PopupBaseMenuItem({
-            reactive: false,
-            can_focus: false,
-        });
-        fiveHourItem.add_child(fiveHourBox);
-        this.menu.addMenuItem(fiveHourItem);
+        // Auto-scan: ~/.claude-*/ directories with .credentials.json
+        try {
+            const homeDir = Gio.File.new_for_path(GLib.get_home_dir());
+            const enumerator = homeDir.enumerate_children(
+                'standard::name,standard::type',
+                Gio.FileQueryInfoFlags.NONE,
+                null
+            );
 
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            let info;
+            while ((info = enumerator.next_file(null)) !== null) {
+                const name = info.get_name();
+                if (info.get_file_type() !== Gio.FileType.DIRECTORY)
+                    continue;
+                if (!name.match(/^\.claude-.+$/))
+                    continue;
 
-        const sevenDayBox = new St.BoxLayout({
-            style_class: 'claude-usage-section',
-            vertical: true,
-        });
-        const sevenDayHeader = new St.BoxLayout({ vertical: false });
-        const sevenDayLabel = new St.Label({
-            text: '7-Day Usage',
-            style_class: 'claude-section-title',
-        });
-        sevenDayHeader.add_child(sevenDayLabel);
-        this._sevenDayPercent = new St.Label({
-            text: '...',
-            style_class: 'claude-percent-label',
-            x_expand: true,
-            x_align: Clutter.ActorAlign.END,
-        });
-        sevenDayHeader.add_child(this._sevenDayPercent);
-        sevenDayBox.add_child(sevenDayHeader);
+                const dirPath = GLib.build_filenamev([GLib.get_home_dir(), name]);
+                const resolved = Gio.File.new_for_path(dirPath).get_path();
+                if (seen.has(resolved))
+                    continue;
 
-        const sevenDayProgressBg = new St.Widget({
-            style_class: 'claude-progress-bg',
-        });
-        this._sevenDayProgressBar = new St.Widget({
-            style_class: 'claude-progress-bar usage-low',
-        });
-        sevenDayProgressBg.add_child(this._sevenDayProgressBar);
-        sevenDayBox.add_child(sevenDayProgressBg);
+                const credFile = Gio.File.new_for_path(
+                    GLib.build_filenamev([dirPath, '.credentials.json'])
+                );
+                if (!credFile.query_exists(null))
+                    continue;
 
-        this._sevenDayResetLabel = new St.Label({
-            text: 'Resets: ...',
-            style_class: 'claude-reset-label',
-        });
-        sevenDayBox.add_child(this._sevenDayResetLabel);
+                seen.add(resolved);
+                const label = name.replace(/^\./, '');
+                results.push({id: label, label, configDir: resolved});
+            }
+            enumerator.close(null);
+        } catch (e) {
+            console.error('Claude Usage: Failed to scan home directory:', e.message);
+        }
 
-        const sevenDayItem = new PopupMenu.PopupBaseMenuItem({
-            reactive: false,
-            can_focus: false,
-        });
-        sevenDayItem.add_child(sevenDayBox);
-        this.menu.addMenuItem(sevenDayItem);
+        // Manual extra accounts from settings
+        const extraAccounts = this._settings.get_strv('extra-accounts');
+        for (const dirPath of extraAccounts) {
+            const resolved = Gio.File.new_for_path(dirPath).get_path();
+            if (seen.has(resolved))
+                continue;
 
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            const credFile = Gio.File.new_for_path(
+                GLib.build_filenamev([resolved, '.credentials.json'])
+            );
+            if (!credFile.query_exists(null))
+                continue;
 
-        const settingsItem = new PopupMenu.PopupMenuItem('Settings');
-        settingsItem.connect('activate', () => {
-            this._openPreferences();
+            seen.add(resolved);
+            const baseName = GLib.path_get_basename(resolved).replace(/^\./, '');
+            results.push({id: baseName, label: baseName, configDir: resolved});
+        }
+
+        // Apply custom labels
+        const accountLabels = this._settings.get_strv('account-labels');
+        for (const entry of accountLabels) {
+            const sepIdx = entry.indexOf('|');
+            if (sepIdx === -1)
+                continue;
+            const path = entry.substring(0, sepIdx);
+            const customLabel = entry.substring(sepIdx + 1);
+            const resolvedPath = Gio.File.new_for_path(path).get_path();
+            const account = results.find(a => a.configDir === resolvedPath);
+            if (account)
+                account.label = customLabel;
+        }
+
+        // Sort: default first, then alphabetical by label
+        results.sort((a, b) => {
+            if (a.id === 'default') return -1;
+            if (b.id === 'default') return 1;
+            return a.label.localeCompare(b.label);
         });
-        this.menu.addMenuItem(settingsItem);
+
+        return results;
     }
+
+    // --- Account lifecycle ---
+
+    _rebuildAccounts() {
+        for (const account of this._accounts) {
+            account.destroy();
+        }
+        this._accounts = [];
+
+        const discovered = this._discoverAccounts();
+        for (const info of discovered) {
+            const account = new AccountState(info.id, info.label, info.configDir);
+            this._startAccountMonitor(account);
+            this._accounts.push(account);
+        }
+
+        this._rebuildMenu();
+        this._refreshAllAccounts();
+    }
+
+    // --- File monitoring per account ---
+
+    _startAccountMonitor(account) {
+        try {
+            const file = Gio.File.new_for_path(account.credentialsPath);
+            account.fileMonitor = file.monitor_file(Gio.FileMonitorFlags.NONE, null);
+            account.fileMonitorSignalId = account.fileMonitor.connect(
+                'changed',
+                (monitor, changedFile, otherFile, eventType) => {
+                    if (eventType === Gio.FileMonitorEvent.CHANGED ||
+                        eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+                        this._debouncedRefreshAccount(account);
+                    }
+                }
+            );
+        } catch (e) {
+            console.error(`Claude Usage: Failed to monitor ${account.credentialsPath}:`, e.message);
+        }
+    }
+
+    _debouncedRefreshAccount(account) {
+        if (account.debounceTimerId) {
+            GLib.source_remove(account.debounceTimerId);
+            account.debounceTimerId = null;
+        }
+        account.debounceTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            account.debounceTimerId = null;
+            if (this._accounts.includes(account))
+                this._refreshAccount(account);
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    // --- Polling ---
 
     _startTimer() {
         const interval = this._settings.get_int('refresh-interval');
@@ -249,7 +330,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             GLib.PRIORITY_DEFAULT,
             interval,
             () => {
-                this._refreshUsage();
+                this._refreshAllAccounts();
                 return GLib.SOURCE_CONTINUE;
             }
         );
@@ -267,123 +348,58 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._startTimer();
     }
 
-    _startCredentialsMonitor() {
-        try {
-            const configDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
-                GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
-            const credentialsPath = GLib.build_filenamev([
-                configDir,
-                '.credentials.json',
-            ]);
-            const file = Gio.File.new_for_path(credentialsPath);
-            this._credentialsMonitor = file.monitor_file(Gio.FileMonitorFlags.NONE, null);
-            this._credentialsMonitorId = this._credentialsMonitor.connect('changed', (monitor, changedFile, otherFile, eventType) => {
-                if (eventType === Gio.FileMonitorEvent.CHANGED ||
-                    eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
-                    this._debouncedRefresh();
-                }
-            });
-        } catch (e) {
-            console.error('Claude Usage: Failed to start credentials monitor:', e.message);
-        }
-    }
-
-    _debouncedRefresh() {
-        if (this._debounceTimerId) {
-            GLib.source_remove(this._debounceTimerId);
-            this._debounceTimerId = null;
-        }
-        this._debounceTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
-            this._debounceTimerId = null;
-            this._refreshUsage();
-            return GLib.SOURCE_REMOVE;
+    _refreshAllAccounts() {
+        this._accounts.forEach((account, index) => {
+            if (index === 0) {
+                this._refreshAccount(account);
+            } else {
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, index * 200, () => {
+                    if (this._accounts.includes(account))
+                        this._refreshAccount(account);
+                    return GLib.SOURCE_REMOVE;
+                });
+            }
         });
     }
 
-    _stopCredentialsMonitor() {
-        if (this._debounceTimerId) {
-            GLib.source_remove(this._debounceTimerId);
-            this._debounceTimerId = null;
-        }
-        if (this._credentialsMonitorId && this._credentialsMonitor) {
-            this._credentialsMonitor.disconnect(this._credentialsMonitorId);
-            this._credentialsMonitorId = null;
-        }
-        if (this._credentialsMonitor) {
-            this._credentialsMonitor.cancel();
-            this._credentialsMonitor = null;
-        }
-    }
+    _refreshAccount(account) {
+        if (!this._accounts.includes(account))
+            return;
 
-    _setExpiredState(expired) {
-        this._isTokenExpired = expired;
-        const effectName = 'expired-desaturate';
+        const file = Gio.File.new_for_path(account.credentialsPath);
+        file.load_contents_async(null, (f, result) => {
+            if (!this._accounts.includes(account))
+                return;
 
-        if (expired) {
-            if (!this._icon.get_effect(effectName)) {
-                this._icon.add_effect(new Clutter.DesaturateEffect({factor: 1.0, name: effectName}));
-            }
-            this._icon.set_opacity(128);
-
-            if (this._cachedData) {
-                const fiveHour = this._cachedData.five_hour?.utilization ?? 0;
-                this._label.set_text(`${Math.round(fiveHour)}% (cached)`);
-                this._fiveHourPercent.set_text(`${fiveHour.toFixed(1)}% (cached)`);
-            } else {
-                this._label.set_text('Expired');
-                this._fiveHourPercent.set_text('Token expired');
-            }
-
-            this._updateExpiredVisibility();
-        } else {
-            this._icon.remove_effect_by_name(effectName);
-            this._icon.set_opacity(255);
-            this.show();
-        }
-    }
-
-    _updateExpiredVisibility() {
-        if (this._isTokenExpired && this._settings.get_boolean('hide-on-expired')) {
-            this.hide();
-        } else {
-            this.show();
-        }
-    }
-
-    _refreshUsage() {
-        const configDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
-            GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
-        const credentialsPath = GLib.build_filenamev([
-            configDir,
-            '.credentials.json',
-        ]);
-
-        const file = Gio.File.new_for_path(credentialsPath);
-        file.load_contents_async(null, (file, result) => {
             try {
-                const [, contents] = file.load_contents_finish(result);
+                const [, contents] = f.load_contents_finish(result);
                 const decoder = new TextDecoder('utf-8');
                 const json = JSON.parse(decoder.decode(contents));
                 const token = json.claudeAiOauth?.accessToken;
 
                 if (!token) {
-                    this._label.set_text('No token');
-                    this._fiveHourPercent.set_text('No credentials');
-                    this._sevenDayPercent.set_text('—');
+                    this._setAccountNoToken(account);
+                    this._updatePanelFromAccounts();
                     return;
                 }
 
-                this._fetchUsage(token);
+                this._fetchAccountUsage(account, token);
             } catch (e) {
-                console.error('Claude Usage: Failed to read credentials:', e.message);
-                this._label.set_text('No token');
-                this._fiveHourPercent.set_text('No credentials');
-                this._sevenDayPercent.set_text('—');
+                console.error(`Claude Usage: Failed to read credentials for ${account.id}:`, e.message);
+                this._setAccountNoToken(account);
+                this._updatePanelFromAccounts();
             }
         });
     }
 
-    _fetchUsage(token) {
+    _setAccountNoToken(account) {
+        if (!account.menuWidgets)
+            return;
+        account.menuWidgets.fiveHourPercent.set_text('No credentials');
+        account.menuWidgets.sevenDayPercent.set_text('—');
+    }
+
+    _fetchAccountUsage(account, token) {
         const message = Soup.Message.new('GET', API_URL);
         message.request_headers.append('Authorization', `Bearer ${token}`);
         message.request_headers.append('anthropic-beta', 'oauth-2025-04-20');
@@ -393,60 +409,296 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
             GLib.PRIORITY_DEFAULT,
             null,
             (session, result) => {
+                if (!this._accounts.includes(account))
+                    return;
+
                 try {
                     const bytes = session.send_and_read_finish(result);
 
                     if (message.status_code === 401) {
-                        this._setExpiredState(true);
+                        this._setAccountExpired(account, true);
+                        this._updatePanelFromAccounts();
                         return;
                     }
 
                     if (message.status_code !== 200) {
-                        this._label.set_text('Error');
-                        this._fiveHourPercent.set_text(`HTTP ${message.status_code}`);
+                        if (account.menuWidgets)
+                            account.menuWidgets.fiveHourPercent.set_text(`HTTP ${message.status_code}`);
                         return;
                     }
 
                     const decoder = new TextDecoder('utf-8');
                     const data = JSON.parse(decoder.decode(bytes.get_data()));
 
-                    this._cachedData = data;
-                    this._setExpiredState(false);
-                    this._updateDisplay(data);
+                    account.cachedData = data;
+                    this._setAccountExpired(account, false);
+                    this._updateAccountMenu(account, data);
+                    this._updatePanelFromAccounts();
                 } catch (e) {
-                    console.error('Claude Usage: Failed to fetch usage:', e.message);
-                    this._label.set_text('Error');
+                    console.error(`Claude Usage: Failed to fetch usage for ${account.id}:`, e.message);
                 }
             }
         );
     }
 
-    _updateDisplay(data) {
+    // --- Menu UI ---
+
+    _rebuildMenu() {
+        this.menu.removeAll();
+
+        if (this._accounts.length === 1) {
+            // Single account: identical layout to original
+            const account = this._accounts[0];
+            account.menuWidgets = this._createUsageSectionWidgets(account);
+        } else {
+            // Multi-account: header per account
+            this._accounts.forEach((account, index) => {
+                // Account header
+                const headerItem = new PopupMenu.PopupBaseMenuItem({
+                    reactive: false,
+                    can_focus: false,
+                });
+                const headerLabel = new St.Label({
+                    text: account.label,
+                    style_class: 'claude-account-header-label',
+                });
+                headerItem.add_child(headerLabel);
+                this.menu.addMenuItem(headerItem);
+
+                account.menuWidgets = this._createUsageSectionWidgets(account);
+
+                if (index < this._accounts.length - 1)
+                    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            });
+        }
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        const settingsItem = new PopupMenu.PopupMenuItem('Settings');
+        settingsItem.connect('activate', () => {
+            this._openPreferences();
+        });
+        this.menu.addMenuItem(settingsItem);
+    }
+
+    _createUsageSectionWidgets(account) {
+        // 5-Hour section
+        const fiveHourBox = new St.BoxLayout({
+            style_class: 'claude-usage-section',
+            vertical: true,
+        });
+        const fiveHourHeader = new St.BoxLayout({vertical: false});
+        const fiveHourLabel = new St.Label({
+            text: '5-Hour Usage',
+            style_class: 'claude-section-title',
+        });
+        fiveHourHeader.add_child(fiveHourLabel);
+        const fiveHourPercent = new St.Label({
+            text: '...',
+            style_class: 'claude-percent-label',
+            x_expand: true,
+            x_align: Clutter.ActorAlign.END,
+        });
+        fiveHourHeader.add_child(fiveHourPercent);
+        fiveHourBox.add_child(fiveHourHeader);
+
+        const fiveHourProgressBg = new St.Widget({
+            style_class: 'claude-progress-bg',
+        });
+        const fiveHourProgressBar = new St.Widget({
+            style_class: 'claude-progress-bar usage-low',
+        });
+        fiveHourProgressBg.add_child(fiveHourProgressBar);
+        fiveHourBox.add_child(fiveHourProgressBg);
+
+        const fiveHourResetLabel = new St.Label({
+            text: 'Resets: ...',
+            style_class: 'claude-reset-label',
+        });
+        fiveHourBox.add_child(fiveHourResetLabel);
+
+        const fiveHourItem = new PopupMenu.PopupBaseMenuItem({
+            reactive: false,
+            can_focus: false,
+        });
+        fiveHourItem.add_child(fiveHourBox);
+        this.menu.addMenuItem(fiveHourItem);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        // 7-Day section
+        const sevenDayBox = new St.BoxLayout({
+            style_class: 'claude-usage-section',
+            vertical: true,
+        });
+        const sevenDayHeader = new St.BoxLayout({vertical: false});
+        const sevenDayLabel = new St.Label({
+            text: '7-Day Usage',
+            style_class: 'claude-section-title',
+        });
+        sevenDayHeader.add_child(sevenDayLabel);
+        const sevenDayPercent = new St.Label({
+            text: '...',
+            style_class: 'claude-percent-label',
+            x_expand: true,
+            x_align: Clutter.ActorAlign.END,
+        });
+        sevenDayHeader.add_child(sevenDayPercent);
+        sevenDayBox.add_child(sevenDayHeader);
+
+        const sevenDayProgressBg = new St.Widget({
+            style_class: 'claude-progress-bg',
+        });
+        const sevenDayProgressBar = new St.Widget({
+            style_class: 'claude-progress-bar usage-low',
+        });
+        sevenDayProgressBg.add_child(sevenDayProgressBar);
+        sevenDayBox.add_child(sevenDayProgressBg);
+
+        const sevenDayResetLabel = new St.Label({
+            text: 'Resets: ...',
+            style_class: 'claude-reset-label',
+        });
+        sevenDayBox.add_child(sevenDayResetLabel);
+
+        const sevenDayItem = new PopupMenu.PopupBaseMenuItem({
+            reactive: false,
+            can_focus: false,
+        });
+        sevenDayItem.add_child(sevenDayBox);
+        this.menu.addMenuItem(sevenDayItem);
+
+        return {
+            fiveHourPercent,
+            fiveHourProgressBar,
+            fiveHourResetLabel,
+            sevenDayPercent,
+            sevenDayProgressBar,
+            sevenDayResetLabel,
+        };
+    }
+
+    _updateAccountMenu(account, data) {
+        if (!account.menuWidgets)
+            return;
+
+        const w = account.menuWidgets;
         const fiveHour = data.five_hour?.utilization ?? 0;
         const sevenDay = data.seven_day?.utilization ?? 0;
 
-        this._label.set_text(`${Math.round(fiveHour)}%`);
+        w.fiveHourPercent.set_text(`${fiveHour.toFixed(1)}%`);
+        this._updateProgressBar(w.fiveHourProgressBar, fiveHour);
 
-        this._updatePanelProgressBar(fiveHour);
-
-        this._fiveHourPercent.set_text(`${fiveHour.toFixed(1)}%`);
-        this._updateProgressBar(this._fiveHourProgressBar, fiveHour);
-
-        this._sevenDayPercent.set_text(`${sevenDay.toFixed(1)}%`);
-        this._updateProgressBar(this._sevenDayProgressBar, sevenDay);
+        w.sevenDayPercent.set_text(`${sevenDay.toFixed(1)}%`);
+        this._updateProgressBar(w.sevenDayProgressBar, sevenDay);
 
         if (data.five_hour?.resets_at) {
-            this._fiveHourResetLabel.set_text(
+            w.fiveHourResetLabel.set_text(
                 `Resets in ${this._formatResetTime(data.five_hour.resets_at)}`
             );
         }
 
         if (data.seven_day?.resets_at) {
-            this._sevenDayResetLabel.set_text(
+            w.sevenDayResetLabel.set_text(
                 `Resets in ${this._formatResetTime(data.seven_day.resets_at)}`
             );
         }
     }
+
+    // --- Panel UI ---
+
+    _updatePanelFromAccounts() {
+        // Find the account with highest 5-hour utilization among non-expired accounts with data
+        let worstAccount = null;
+        let worstUsage = -1;
+
+        for (const account of this._accounts) {
+            if (account.isTokenExpired || !account.cachedData)
+                continue;
+            const usage = account.cachedData.five_hour?.utilization ?? 0;
+            if (usage > worstUsage) {
+                worstUsage = usage;
+                worstAccount = account;
+            }
+        }
+
+        // If all expired/no data, try cached data from expired accounts
+        if (!worstAccount) {
+            for (const account of this._accounts) {
+                if (!account.cachedData)
+                    continue;
+                const usage = account.cachedData.five_hour?.utilization ?? 0;
+                if (usage > worstUsage) {
+                    worstUsage = usage;
+                    worstAccount = account;
+                }
+            }
+        }
+
+        if (worstAccount) {
+            const usage = worstUsage;
+            const suffix = worstAccount.isTokenExpired ? ' (cached)' : '';
+
+            if (this._accounts.length === 1) {
+                this._label.set_text(`${Math.round(usage)}%${suffix}`);
+            } else {
+                this._label.set_text(`${worstAccount.label}: ${Math.round(usage)}%${suffix}`);
+            }
+
+            this._updatePanelProgressBar(usage);
+        } else {
+            this._label.set_text('...');
+            this._updatePanelProgressBar(0);
+        }
+
+        // Global expired state
+        const allExpired = this._accounts.length > 0 &&
+            this._accounts.every(a => a.isTokenExpired);
+        this._setGlobalExpiredState(allExpired);
+    }
+
+    _setAccountExpired(account, expired) {
+        account.isTokenExpired = expired;
+
+        if (!account.menuWidgets)
+            return;
+
+        if (expired) {
+            if (account.cachedData) {
+                const fiveHour = account.cachedData.five_hour?.utilization ?? 0;
+                account.menuWidgets.fiveHourPercent.set_text(`${fiveHour.toFixed(1)}% (cached)`);
+            } else {
+                account.menuWidgets.fiveHourPercent.set_text('Token expired');
+            }
+        }
+    }
+
+    _setGlobalExpiredState(allExpired) {
+        this._allTokensExpired = allExpired;
+        const effectName = 'expired-desaturate';
+
+        if (allExpired) {
+            if (!this._icon.get_effect(effectName)) {
+                this._icon.add_effect(new Clutter.DesaturateEffect({factor: 1.0, name: effectName}));
+            }
+            this._icon.set_opacity(128);
+            this._updateExpiredVisibility();
+        } else {
+            this._icon.remove_effect_by_name(effectName);
+            this._icon.set_opacity(255);
+            this.show();
+        }
+    }
+
+    _updateExpiredVisibility() {
+        if (this._allTokensExpired && this._settings.get_boolean('hide-on-expired')) {
+            this.hide();
+        } else {
+            this.show();
+        }
+    }
+
+    // --- Progress bars ---
 
     _updatePanelProgressBar(usage) {
         const maxWidth = 50;
@@ -475,6 +727,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         }
     }
 
+    // --- Utilities ---
+
     _formatResetTime(isoString) {
         try {
             const resetDate = new Date(isoString);
@@ -502,9 +756,11 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     destroy() {
-        this._stopCredentialsMonitor();
-        this._cachedData = null;
         this._stopTimer();
+        for (const account of this._accounts) {
+            account.destroy();
+        }
+        this._accounts = [];
         if (this._session) {
             this._session.abort();
             this._session = null;

--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._recreateSession();
             } else if (key === 'icon-style') {
                 this._updateIconStyle();
+                this._updatePanelFromAccounts();
             } else if (key === 'hide-on-expired') {
                 this._updateExpiredVisibility();
             } else if (key === 'extra-accounts' || key === 'account-labels') {
@@ -761,9 +762,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._box.add_child(bg);
                 this._pinnedPanelWidgets.push(bg);
 
-                const maxWidth = 50;
-                const width = Math.round((Math.min(100, Math.max(0, usage)) / 100) * maxWidth);
-                bar.set_width(width);
+                this._updatePanelProgressBar(usage, bar);
             }
 
             // Text and both modes: show percentage text
@@ -834,10 +833,28 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
     // --- Progress bars ---
 
-    _updatePanelProgressBar(usage) {
+    _updatePanelProgressBar(usage, bar = null) {
+        const targetBar = bar ?? this._panelProgressBar;
         const maxWidth = 50;
         const width = Math.round((Math.min(100, Math.max(0, usage)) / 100) * maxWidth);
-        this._panelProgressBar.set_width(width);
+        targetBar.set_width(width);
+
+        targetBar.remove_style_class_name('usage-low');
+        targetBar.remove_style_class_name('usage-medium');
+        targetBar.remove_style_class_name('usage-high');
+        targetBar.remove_style_class_name('usage-critical');
+
+        if (this._settings.get_string('icon-style') === 'color') {
+            if (usage >= 90) {
+                targetBar.add_style_class_name('usage-critical');
+            } else if (usage >= 70) {
+                targetBar.add_style_class_name('usage-high');
+            } else if (usage >= 40) {
+                targetBar.add_style_class_name('usage-medium');
+            } else {
+                targetBar.add_style_class_name('usage-low');
+            }
+        }
     }
 
     _updateProgressBar(progressBar, usage) {

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   "donations": {
     "github": "Haletran"
   },
-  "version": 3
+  "version": 5
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,6 +1,7 @@
 import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
@@ -38,6 +39,9 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             Gio.SettingsBindFlags.DEFAULT
         );
         generalGroup.add(refreshRow);
+
+        // --- Accounts group ---
+        this._buildAccountsGroup(page, settings);
 
         const displayGroup = new Adw.PreferencesGroup({
             title: 'Panel Display',
@@ -136,5 +140,248 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             margin_top: 4,
         });
         networkGroup.add(proxyHint);
+    }
+
+    _buildAccountsGroup(page, settings) {
+        const accountsGroup = new Adw.PreferencesGroup({
+            title: 'Accounts',
+            description: 'Directories matching ~/.claude-*/ are detected automatically',
+        });
+        page.add(accountsGroup);
+
+        const accounts = this._discoverAccountPaths(settings);
+        const accountLabels = settings.get_strv('account-labels');
+        const extraAccounts = settings.get_strv('extra-accounts');
+
+        for (const account of accounts) {
+            const currentLabel = this._getLabelForPath(account.path, accountLabels) ?? account.defaultLabel;
+
+            const row = new Adw.EntryRow({
+                title: account.path,
+                show_apply_button: true,
+            });
+            row.set_text(currentLabel);
+
+            row.connect('apply', () => {
+                const newLabel = row.get_text().trim();
+                this._setLabelForPath(settings, account.path, newLabel);
+            });
+
+            // Add delete button for manually added accounts only
+            if (account.isManual) {
+                const deleteButton = new Gtk.Button({
+                    icon_name: 'edit-delete-symbolic',
+                    valign: Gtk.Align.CENTER,
+                    css_classes: ['flat'],
+                    tooltip_text: 'Remove this account',
+                });
+                deleteButton.connect('clicked', () => {
+                    const current = settings.get_strv('extra-accounts');
+                    const updated = current.filter(p => p !== account.path);
+                    settings.set_strv('extra-accounts', updated);
+                    accountsGroup.remove(row);
+                });
+                row.add_suffix(deleteButton);
+            }
+
+            accountsGroup.add(row);
+        }
+
+        // Add account button
+        const addRow = new Adw.ActionRow({
+            title: 'Add Account',
+            subtitle: 'Add a custom config directory path',
+            activatable: true,
+        });
+        addRow.add_suffix(new Gtk.Image({
+            icon_name: 'list-add-symbolic',
+            valign: Gtk.Align.CENTER,
+        }));
+        addRow.connect('activated', () => {
+            this._showAddAccountDialog(page.get_root(), settings, accountsGroup, addRow);
+        });
+        accountsGroup.add(addRow);
+    }
+
+    _discoverAccountPaths(settings) {
+        const seen = new Set();
+        const results = [];
+
+        // Default account
+        const defaultDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
+            GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
+        const defaultResolved = Gio.File.new_for_path(defaultDir).get_path();
+        seen.add(defaultResolved);
+        results.push({
+            path: defaultResolved,
+            defaultLabel: 'default',
+            isManual: false,
+        });
+
+        // Auto-scan ~/.claude-*/
+        try {
+            const homeDir = Gio.File.new_for_path(GLib.get_home_dir());
+            const enumerator = homeDir.enumerate_children(
+                'standard::name,standard::type',
+                Gio.FileQueryInfoFlags.NONE,
+                null
+            );
+
+            let info;
+            while ((info = enumerator.next_file(null)) !== null) {
+                const name = info.get_name();
+                if (info.get_file_type() !== Gio.FileType.DIRECTORY)
+                    continue;
+                if (!name.match(/^\.claude-.+$/))
+                    continue;
+
+                const dirPath = GLib.build_filenamev([GLib.get_home_dir(), name]);
+                const resolved = Gio.File.new_for_path(dirPath).get_path();
+                if (seen.has(resolved))
+                    continue;
+
+                const credFile = Gio.File.new_for_path(
+                    GLib.build_filenamev([dirPath, '.credentials.json'])
+                );
+                if (!credFile.query_exists(null))
+                    continue;
+
+                seen.add(resolved);
+                results.push({
+                    path: resolved,
+                    defaultLabel: name.replace(/^\./, ''),
+                    isManual: false,
+                });
+            }
+            enumerator.close(null);
+        } catch (e) {
+            console.error('Claude Usage Prefs: Failed to scan home directory:', e.message);
+        }
+
+        // Manual extra accounts
+        const extraAccounts = settings.get_strv('extra-accounts');
+        for (const dirPath of extraAccounts) {
+            const resolved = Gio.File.new_for_path(dirPath).get_path();
+            if (seen.has(resolved))
+                continue;
+
+            seen.add(resolved);
+            const baseName = GLib.path_get_basename(resolved).replace(/^\./, '');
+            results.push({
+                path: resolved,
+                defaultLabel: baseName,
+                isManual: true,
+            });
+        }
+
+        return results;
+    }
+
+    _getLabelForPath(path, accountLabels) {
+        const resolved = Gio.File.new_for_path(path).get_path();
+        for (const entry of accountLabels) {
+            const sepIdx = entry.indexOf('|');
+            if (sepIdx === -1)
+                continue;
+            const entryPath = entry.substring(0, sepIdx);
+            const entryLabel = entry.substring(sepIdx + 1);
+            if (Gio.File.new_for_path(entryPath).get_path() === resolved)
+                return entryLabel;
+        }
+        return null;
+    }
+
+    _setLabelForPath(settings, path, label) {
+        const resolved = Gio.File.new_for_path(path).get_path();
+        const current = settings.get_strv('account-labels');
+        const filtered = current.filter(entry => {
+            const sepIdx = entry.indexOf('|');
+            if (sepIdx === -1) return false;
+            const entryPath = entry.substring(0, sepIdx);
+            return Gio.File.new_for_path(entryPath).get_path() !== resolved;
+        });
+        if (label)
+            filtered.push(`${resolved}|${label}`);
+        settings.set_strv('account-labels', filtered);
+    }
+
+    _showAddAccountDialog(parentWindow, settings, accountsGroup, addRow) {
+        const dialog = new Adw.AlertDialog({
+            heading: 'Add Account',
+            body: 'Enter the full path to a Claude config directory containing .credentials.json',
+        });
+
+        const entry = new Gtk.Entry({
+            placeholder_text: '/home/user/.claude-work',
+            hexpand: true,
+        });
+        dialog.set_extra_child(entry);
+
+        dialog.add_response('cancel', 'Cancel');
+        dialog.add_response('add', 'Add');
+        dialog.set_response_appearance('add', Adw.ResponseAppearance.SUGGESTED);
+
+        dialog.connect('response', (dlg, response) => {
+            if (response !== 'add')
+                return;
+
+            const path = entry.get_text().trim();
+            if (!path)
+                return;
+
+            const resolved = Gio.File.new_for_path(path).get_path();
+            const credFile = Gio.File.new_for_path(
+                GLib.build_filenamev([resolved, '.credentials.json'])
+            );
+
+            if (!credFile.query_exists(null)) {
+                const errorDialog = new Adw.AlertDialog({
+                    heading: 'Invalid Path',
+                    body: `No .credentials.json found in ${resolved}`,
+                });
+                errorDialog.add_response('ok', 'OK');
+                errorDialog.present(parentWindow);
+                return;
+            }
+
+            const current = settings.get_strv('extra-accounts');
+            if (!current.includes(resolved)) {
+                current.push(resolved);
+                settings.set_strv('extra-accounts', current);
+            }
+
+            // Add a row dynamically
+            const baseName = GLib.path_get_basename(resolved).replace(/^\./, '');
+            const row = new Adw.EntryRow({
+                title: resolved,
+                show_apply_button: true,
+            });
+            row.set_text(baseName);
+            row.connect('apply', () => {
+                const newLabel = row.get_text().trim();
+                this._setLabelForPath(settings, resolved, newLabel);
+            });
+
+            const deleteButton = new Gtk.Button({
+                icon_name: 'edit-delete-symbolic',
+                valign: Gtk.Align.CENTER,
+                css_classes: ['flat'],
+                tooltip_text: 'Remove this account',
+            });
+            deleteButton.connect('clicked', () => {
+                const cur = settings.get_strv('extra-accounts');
+                const updated = cur.filter(p => p !== resolved);
+                settings.set_strv('extra-accounts', updated);
+                accountsGroup.remove(row);
+            });
+            row.add_suffix(deleteButton);
+
+            // Insert before the "Add" row
+            accountsGroup.remove(addRow);
+            accountsGroup.add(row);
+            accountsGroup.add(addRow);
+        });
+
+        dialog.present(parentWindow);
     }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -100,6 +100,18 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         );
         displayGroup.add(showIconRow);
 
+        const hideOnExpiredRow = new Adw.SwitchRow({
+            title: 'Hide on Expired Token',
+            subtitle: 'Hide the indicator when the OAuth token has expired',
+        });
+        settings.bind(
+            'hide-on-expired',
+            hideOnExpiredRow,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        displayGroup.add(hideOnExpiredRow);
+
         const networkGroup = new Adw.PreferencesGroup({
             title: 'Network',
             description: 'Configure network settings',

--- a/prefs.js
+++ b/prefs.js
@@ -41,13 +41,42 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         generalGroup.add(refreshRow);
 
         // --- Accounts group ---
-        this._buildAccountsGroup(page, settings);
+        const accounts = this._discoverAccountPaths(settings);
+        const isMultiAccount = accounts.length >= 2;
+        this._buildAccountsGroup(page, settings, accounts, isMultiAccount);
 
         const displayGroup = new Adw.PreferencesGroup({
             title: 'Panel Display',
             description: 'Configure how usage is shown in the top panel',
         });
         page.add(displayGroup);
+
+        // Panel Account Mode (only for 2+ accounts)
+        if (isMultiAccount) {
+            const accountModeRow = new Adw.ComboRow({
+                title: 'Panel Account Mode',
+                subtitle: 'Which account to show in the top panel',
+            });
+
+            const accountModeModel = new Gtk.StringList();
+            accountModeModel.append('Highest usage');
+            accountModeModel.append('Lowest usage');
+            accountModeModel.append('Pinned accounts');
+            accountModeRow.set_model(accountModeModel);
+
+            const currentAccountMode = settings.get_string('panel-account-mode');
+            const accountModeIndex = currentAccountMode === 'lowest' ? 1
+                : currentAccountMode === 'pinned' ? 2 : 0;
+            accountModeRow.set_selected(accountModeIndex);
+
+            accountModeRow.connect('notify::selected', () => {
+                const selected = accountModeRow.get_selected();
+                const modes = ['highest', 'lowest', 'pinned'];
+                settings.set_string('panel-account-mode', modes[selected]);
+            });
+
+            displayGroup.add(accountModeRow);
+        }
 
         const displayModeRow = new Adw.ComboRow({
             title: 'Display Mode',
@@ -142,16 +171,14 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         networkGroup.add(proxyHint);
     }
 
-    _buildAccountsGroup(page, settings) {
+    _buildAccountsGroup(page, settings, accounts, isMultiAccount) {
         const accountsGroup = new Adw.PreferencesGroup({
             title: 'Accounts',
             description: 'Directories matching ~/.claude-*/ are detected automatically',
         });
         page.add(accountsGroup);
 
-        const accounts = this._discoverAccountPaths(settings);
         const accountLabels = settings.get_strv('account-labels');
-        const extraAccounts = settings.get_strv('extra-accounts');
 
         for (const account of accounts) {
             const currentLabel = this._getLabelForPath(account.path, accountLabels) ?? account.defaultLabel;
@@ -166,6 +193,10 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                 const newLabel = row.get_text().trim();
                 this._setLabelForPath(settings, account.path, newLabel);
             });
+
+            // Pin button (only for 2+ accounts)
+            if (isMultiAccount)
+                this._addPinButton(row, account.path, settings);
 
             // Add delete button for manually added accounts only
             if (account.isManual) {
@@ -198,7 +229,7 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             valign: Gtk.Align.CENTER,
         }));
         addRow.connect('activated', () => {
-            this._showAddAccountDialog(page.get_root(), settings, accountsGroup, addRow);
+            this._showAddAccountDialog(page.get_root(), settings, accountsGroup, addRow, isMultiAccount);
         });
         accountsGroup.add(addRow);
     }
@@ -305,7 +336,56 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         settings.set_strv('account-labels', filtered);
     }
 
-    _showAddAccountDialog(parentWindow, settings, accountsGroup, addRow) {
+    _addPinButton(row, accountPath, settings) {
+        const pinned = settings.get_strv('pinned-accounts');
+        const isPinned = pinned.includes(accountPath);
+
+        const pinButton = new Gtk.ToggleButton({
+            icon_name: 'view-pin-symbolic',
+            valign: Gtk.Align.CENTER,
+            css_classes: ['flat'],
+            active: isPinned,
+        });
+
+        const updateOpacityAndTooltip = () => {
+            const mode = settings.get_string('panel-account-mode');
+            if (mode === 'pinned') {
+                pinButton.set_opacity(1.0);
+                pinButton.set_tooltip_text(
+                    pinButton.get_active() ? 'Unpin from panel' : 'Pin to panel'
+                );
+            } else {
+                pinButton.set_opacity(0.5);
+                pinButton.set_tooltip_text('Switch to "Pinned accounts" mode to use pins');
+            }
+        };
+        updateOpacityAndTooltip();
+
+        pinButton.connect('toggled', () => {
+            const current = settings.get_strv('pinned-accounts');
+            if (pinButton.get_active()) {
+                if (!current.includes(accountPath)) {
+                    current.push(accountPath);
+                    settings.set_strv('pinned-accounts', current);
+                }
+            } else {
+                const updated = current.filter(p => p !== accountPath);
+                settings.set_strv('pinned-accounts', updated);
+            }
+            updateOpacityAndTooltip();
+        });
+
+        const modeChangedId = settings.connect('changed::panel-account-mode', () => {
+            updateOpacityAndTooltip();
+        });
+        row.connect('destroy', () => {
+            settings.disconnect(modeChangedId);
+        });
+
+        row.add_suffix(pinButton);
+    }
+
+    _showAddAccountDialog(parentWindow, settings, accountsGroup, addRow, isMultiAccount) {
         const dialog = new Adw.AlertDialog({
             heading: 'Add Account',
             body: 'Enter the full path to a Claude config directory containing .credentials.json',
@@ -361,6 +441,10 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
                 const newLabel = row.get_text().trim();
                 this._setLabelForPath(settings, resolved, newLabel);
             });
+
+            // Pin button (adding a new account means we now have 2+ accounts)
+            if (isMultiAccount)
+                this._addPinButton(row, resolved, settings);
 
             const deleteButton = new Gtk.Button({
                 icon_name: 'edit-delete-symbolic',

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -41,5 +41,15 @@
       <summary>Account custom labels</summary>
       <description>Custom labels in format 'path|label'. Example: '/home/user/.claude-work|Work'</description>
     </key>
+    <key name="panel-account-mode" type="s">
+      <default>'highest'</default>
+      <summary>Panel account selection mode</summary>
+      <description>Which account to show: 'highest', 'lowest', or 'pinned'</description>
+    </key>
+    <key name="pinned-accounts" type="as">
+      <default>[]</default>
+      <summary>Pinned account config directories</summary>
+      <description>Config directory paths of accounts to always show when mode is 'pinned'</description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -26,5 +26,10 @@
       <summary>Proxy URL</summary>
       <description>HTTP proxy URL (e.g., http://localhost:11809). Leave empty to use no proxy.</description>
     </key>
+    <key name="hide-on-expired" type="b">
+      <default>false</default>
+      <summary>Hide on expired token</summary>
+      <description>Hide the indicator when the OAuth token has expired</description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -31,5 +31,15 @@
       <summary>Hide on expired token</summary>
       <description>Hide the indicator when the OAuth token has expired</description>
     </key>
+    <key name="extra-accounts" type="as">
+      <default>[]</default>
+      <summary>Extra account config directories</summary>
+      <description>Manually added config directory paths to monitor. Auto-detected directories (~/.claude*/) are always included.</description>
+    </key>
+    <key name="account-labels" type="as">
+      <default>[]</default>
+      <summary>Account custom labels</summary>
+      <description>Custom labels in format 'path|label'. Example: '/home/user/.claude-work|Work'</description>
+    </key>
   </schema>
 </schemalist>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -34,18 +34,16 @@
 .claude-section-title {
     font-size: 13px;
     font-weight: 600;
-    color: #e0e0e0;
 }
 
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #ffffff;
 }
 
 /* Progress bar styles */
 .claude-progress-bg {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(128, 128, 128, 0.2);
     border-radius: 4px;
     height: 8px;
     width: 200px;
@@ -77,7 +75,7 @@
 /* Reset label styles */
 .claude-reset-label {
     font-size: 11px;
-    color: #a0a0a0;
+    opacity: 0.6;
 }
 
 /* Footer styles */
@@ -112,6 +110,6 @@
 .claude-account-header-label {
     font-size: 13px;
     font-weight: bold;
-    color: #cc9544;
+    color: #b37a2e;
     margin-top: 2px;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -107,3 +107,11 @@
     font-style: italic;
     color: #808080;
 }
+
+/* Account header label (multi-account mode) */
+.claude-account-header-label {
+    font-size: 13px;
+    font-weight: bold;
+    color: #cc9544;
+    margin-top: 2px;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -24,6 +24,22 @@
     background-color: #ffffff;
 }
 
+.claude-panel-progress-bar.usage-low {
+    background-color: #22c55e;
+}
+
+.claude-panel-progress-bar.usage-medium {
+    background-color: #eab308;
+}
+
+.claude-panel-progress-bar.usage-high {
+    background-color: #f97316;
+}
+
+.claude-panel-progress-bar.usage-critical {
+    background-color: #ef4444;
+}
+
 /* Usage section styles */
 .claude-usage-section {
     padding: 4px 0;


### PR DESCRIPTION
## Summary

  This PR adds three features to improve the extension's usability for power users and multi-account setups:

  - **Graceful expired token handling** — When an OAuth token expires, the extension now caches the last known data, shows a "(cached)" label, desaturates the icon, and monitors the credentials file for changes to auto-refresh. A new "Hide on Expired  Token" toggle in preferences lets users hide the indicator entirely when the token is expired.
  - **Multi-account support with auto-discovery** — The extension automatically detects `~/.claude-*/` directories containing `.credentials.json` and monitors all accounts simultaneously. The panel displays the highest utilization across all accounts, and  the dropdown menu shows per-account usage sections. Accounts can also be added manually and labeled via a new "Accounts" preferences group.
  - **Theme-compatible styling** — Removed hardcoded colors from section titles, percent labels, and reset labels so they inherit GNOME Shell theme colors. Uses opacity and neutral semi-transparent backgrounds for better light/dark theme compatibility.

  ## Details

  ### Expired token handling (`98eef9a`)
  - Monitors `~/.claude/.credentials.json` for changes (debounced 500ms) and auto-refreshes on token update
  - On HTTP 401: caches last data, shows "(cached)" suffix, desaturates the panel icon
  - New `hide-on-expired` setting to completely hide the indicator when token is expired
  - New preference toggle: "Hide on Expired Token"

  ### Multi-account support (`10f9677`)
  - New `AccountState` class to manage per-account state (credentials, file monitors, cached data, menu widgets)
  - Auto-discovers `~/.claude-*/` directories in the home folder
  - Respects `$CLAUDE_CONFIG_DIR` for the default account
  - Panel text shows the highest utilization across all accounts
  - Dropdown menu displays per-account sections with individual progress bars
  - New settings: `extra-accounts` (manually added config dirs) and `account-labels` (custom labels in `path|label` format)
  - Full preferences UI for managing accounts: auto-detected accounts are listed with editable labels, manual accounts can be added/removed

  ### Theme compatibility (`6e7fdf7`)
  - Removed hardcoded `color` values from `.claude-section-title`, `.claude-percent-label`, `.claude-reset-label`
  - Progress bar background uses neutral `rgba(128, 128, 128, 0.2)` instead of white-based color
  - Reset label uses `opacity: 0.6` instead of fixed gray color

  ## Screenshots
<img width="780" height="634" alt="Capture d’écran du 2026-02-19 17-39-23" src="https://github.com/user-attachments/assets/0c2a5bbf-1d2a-454d-8860-736463638f41" />
<img width="927" height="999" alt="Capture d’écran du 2026-02-19 17-39-41" src="https://github.com/user-attachments/assets/9d9e4ad4-4b19-4b9f-bd08-83c5f5de921b" />


It works great ! And thanks for this extension.