### PR TITLE
Fix colors for both light and dark themes

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -10,7 +10,7 @@
 
 /* Panel progress bar */
 .claude-panel-progress-bg {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(200, 200, 200, 0.4);
     border-radius: 3px;
     height: 10px;
     width: 50px;
@@ -21,7 +21,7 @@
     height: 10px;
     border-radius: 3px;
     transition: width 300ms ease-out;
-    background-color: #ffffff;
+    background-color: #22c55e;
 }
 
 /* Usage section styles */
@@ -34,18 +34,16 @@
 .claude-section-title {
     font-size: 13px;
     font-weight: 600;
-    color: #e0e0e0;
 }
 
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #ffffff;
 }
 
 /* Progress bar styles */
 .claude-progress-bg {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(128, 128, 128, 0.2);
     border-radius: 4px;
     height: 8px;
     width: 200px;
@@ -77,7 +75,7 @@
 /* Reset label styles */
 .claude-reset-label {
     font-size: 11px;
-    color: #a0a0a0;
+    opacity: 0.55;
 }
 
 /* Footer styles */
@@ -89,21 +87,20 @@
 .claude-refresh-button {
     padding: 4px 12px;
     border-radius: 4px;
-    background-color: rgba(255, 255, 255, 0.1);
-    color: #ffffff;
+    background-color: rgba(128, 128, 128, 0.15);
     font-size: 12px;
 }
 
 .claude-refresh-button:hover {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(128, 128, 128, 0.25);
 }
 
 .claude-refresh-button:active {
-    background-color: rgba(255, 255, 255, 0.15);
+    background-color: rgba(128, 128, 128, 0.2);
 }
 
 .claude-last-updated-label {
     font-size: 10px;
     font-style: italic;
-    color: #808080;
+    opacity: 0.5;
 }


### PR DESCRIPTION
- Replace hardcoded white/light color values with neutral `rgba()` colors and `opacity` so the extension looks correct on both light and dark GNOME Shell themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)