### PR TITLE
feat: add Refresh item and icons to popup menu

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,9 +28,9 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         });
 
         const iconPath = GLib.build_filenamev([this._extensionPath, 'claude-icon-22.png']);
-        const gicon = Gio.icon_new_for_string(iconPath);
+        this._originalGicon = Gio.icon_new_for_string(iconPath);
         this._icon = new St.Icon({
-            gicon: gicon,
+            gicon: this._originalGicon,
             style_class: 'claude-icon',
             icon_size: 16,
         });
@@ -142,6 +142,20 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     _createMenu() {
+        const refreshItem = new PopupMenu.PopupMenuItem('Refresh');
+        this._refreshIcon = new St.Icon({
+            icon_name: 'view-refresh-symbolic',
+            style_class: 'popup-menu-icon',
+            icon_size: 16,
+        });
+        refreshItem.insert_child_at_index(this._refreshIcon, 0);
+        refreshItem.connect('activate', () => {
+            this._pendingRefreshFeedback = true;
+            this._refreshUsage();
+        });
+        this.menu.addMenuItem(refreshItem);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         const fiveHourBox = new St.BoxLayout({
             style_class: 'claude-usage-section',
             vertical: true,
@@ -229,6 +243,12 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         const settingsItem = new PopupMenu.PopupMenuItem('Settings');
+        const settingsIcon = new St.Icon({
+            icon_name: 'preferences-system-symbolic',
+            style_class: 'popup-menu-icon',
+            icon_size: 16,
+        });
+        settingsItem.insert_child_at_index(settingsIcon, 0);
         settingsItem.connect('activate', () => {
             this._openPreferences();
         });
@@ -348,6 +368,36 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 `Resets in ${this._formatResetTime(data.seven_day.resets_at)}`
             );
         }
+
+        if (this._pendingRefreshFeedback) {
+            this._pendingRefreshFeedback = false;
+            this._showRefreshSuccess();
+        }
+    }
+
+    _showRefreshSuccess() {
+        this._refreshIcon.set_icon_name('emblem-ok-symbolic');
+
+        this._icon.set_gicon(null);
+        this._icon.set_icon_name('view-refresh-symbolic');
+        this._icon.add_style_class_name('claude-success-flash');
+        this._label.add_style_class_name('claude-success-flash');
+
+        this._refreshFeedbackTimer = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            2,
+            () => {
+                this._refreshIcon.set_icon_name('view-refresh-symbolic');
+
+                this._icon.set_icon_name('');
+                this._icon.set_gicon(this._originalGicon);
+                this._icon.remove_style_class_name('claude-success-flash');
+                this._label.remove_style_class_name('claude-success-flash');
+
+                this._refreshFeedbackTimer = null;
+                return GLib.SOURCE_REMOVE;
+            }
+        );
     }
 
     _updatePanelProgressBar(usage) {
@@ -404,6 +454,10 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
     }
 
     destroy() {
+        if (this._refreshFeedbackTimer) {
+            GLib.source_remove(this._refreshFeedbackTimer);
+            this._refreshFeedbackTimer = null;
+        }
         this._stopTimer();
         if (this._session) {
             this._session.abort();

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   "donations": {
     "github": "Haletran"
   },
-  "version": 3
+  "version": 5
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -107,3 +107,8 @@
     font-style: italic;
     color: #808080;
 }
+
+.claude-success-flash {
+    color: #22c55e;
+    transition: color 150ms ease-out;
+}


### PR DESCRIPTION
## Summary

- Add a **Refresh** menu item at the top of the popup with a refresh icon
- Show a checkmark icon and green panel flash for 2s after a successful refresh
- Add a gear icon to the **Settings** menu item

## Screenshot

<img width="336" height="431" alt="image" src="https://github.com/user-attachments/assets/fe62098b-054c-4da9-b28d-eab066747ab7" />
