### PR TITLE
feat: independent OAuth via PKCE flow

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,9 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const API_URL = 'https://api.anthropic.com/api/oauth/usage';
+const TOKEN_URL = 'https://api.anthropic.com/v1/oauth/token';
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 const ClaudeUsageIndicator = GObject.registerClass(
 class ClaudeUsageIndicator extends PanelMenu.Button {
@@ -259,7 +262,70 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         this._startTimer();
     }
 
+    _setErrorState(msg) {
+        this._label.set_text('Error');
+        this._fiveHourPercent.set_text(msg);
+    }
+
     _refreshUsage() {
+        if (this._fetching) return;
+        this._fetching = true;
+        const ownToken = this._settings.get_string('access-token');
+        if (ownToken) {
+            const expiresAt = this._settings.get_int64('expires-at');
+            if (Date.now() >= expiresAt - TOKEN_EXPIRY_BUFFER_MS) {
+                this._refreshOwnToken();
+            } else {
+                this._fetchUsage(ownToken);
+            }
+        } else {
+            this._loadCredentialsAndFetch();
+        }
+    }
+
+    _refreshOwnToken() {
+        const refreshToken = this._settings.get_string('refresh-token');
+        if (!refreshToken) {
+            this._fetching = false;
+            this._setErrorState('Not connected');
+            return;
+        }
+
+        const body = [
+            'grant_type=refresh_token',
+            `refresh_token=${encodeURIComponent(refreshToken)}`,
+            `client_id=${CLIENT_ID}`,
+        ].join('&');
+
+        const message = Soup.Message.new('POST', TOKEN_URL);
+        message.request_headers.append('Content-Type', 'application/x-www-form-urlencoded');
+        message.set_request_body_from_bytes(
+            null,
+            new GLib.Bytes(new TextEncoder().encode(body))
+        );
+
+        this._session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null, (session, result) => {
+            try {
+                const bytes = session.send_and_read_finish(result);
+                if (message.status_code !== 200) {
+                    this._fetching = false;
+                    this._setErrorState('Auth expired');
+                    return;
+                }
+                const resp = JSON.parse(new TextDecoder().decode(bytes.get_data()));
+                this._settings.set_string('access-token', resp.access_token);
+                this._settings.set_string('refresh-token', resp.refresh_token);
+                this._settings.set_int64('expires-at', Date.now() + (resp.expires_in ?? 28800) * 1000);
+                this._fetchUsage(resp.access_token);
+            } catch (e) {
+                console.error('Claude Usage: Token refresh failed:', e.message);
+                this._fetching = false;
+                this._setErrorState('Error');
+            }
+        });
+    }
+
+    _loadCredentialsAndFetch() {
         const configDir = GLib.getenv('CLAUDE_CONFIG_DIR') ??
             GLib.build_filenamev([GLib.get_home_dir(), '.claude']);
         const credentialsPath = GLib.build_filenamev([
@@ -276,6 +342,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 const token = json.claudeAiOauth?.accessToken;
 
                 if (!token) {
+                    this._fetching = false;
                     this._label.set_text('No token');
                     this._fiveHourPercent.set_text('No credentials');
                     this._sevenDayPercent.set_text('—');
@@ -285,6 +352,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._fetchUsage(token);
             } catch (e) {
                 console.error('Claude Usage: Failed to read credentials:', e.message);
+                this._fetching = false;
                 this._label.set_text('No token');
                 this._fiveHourPercent.set_text('No credentials');
                 this._sevenDayPercent.set_text('—');
@@ -305,9 +373,13 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 try {
                     const bytes = session.send_and_read_finish(result);
 
+                    if (message.status_code === 429) {
+                        this._fetching = false;
+                        return; // rate limited — keep last known data
+                    }
                     if (message.status_code !== 200) {
-                        this._label.set_text('Error');
-                        this._fiveHourPercent.set_text(`HTTP ${message.status_code}`);
+                        this._fetching = false;
+                        this._setErrorState(`HTTP ${message.status_code}`);
                         return;
                     }
 
@@ -315,9 +387,11 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                     const data = JSON.parse(decoder.decode(bytes.get_data()));
 
                     this._updateDisplay(data);
+                    this._fetching = false;
                 } catch (e) {
                     console.error('Claude Usage: Failed to fetch usage:', e.message);
-                    this._label.set_text('Error');
+                    this._fetching = false;
+                    this._setErrorState('Error');
                 }
             }
         );

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   "donations": {
     "github": "Haletran"
   },
-  "version": 3
+  "version": 6
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,8 +1,31 @@
 import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Soup from 'gi://Soup';
 
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+const AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
+const TOKEN_URL = 'https://api.anthropic.com/v1/oauth/token';
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
+const OAUTH_SCOPES = 'user:profile user:inference';
+
+function generateCodeVerifier() {
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++)
+        bytes[i] = GLib.random_int_range(0, 256);
+    return GLib.base64_encode(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function codeChallenge(verifier) {
+    const hex = GLib.compute_checksum_for_string(GLib.ChecksumType.SHA256, verifier, -1);
+    const raw = new Uint8Array(32);
+    for (let i = 0; i < 32; i++)
+        raw[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    return GLib.base64_encode(raw).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
 
 export default class ClaudeUsagePreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -124,5 +147,195 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
             margin_top: 4,
         });
         networkGroup.add(proxyHint);
+
+        // Authentication group
+        const authGroup = new Adw.PreferencesGroup({
+            title: 'Authentication',
+            description: 'Connect your Claude account so the extension manages its own token',
+        });
+        page.add(authGroup);
+
+        const isConnected = () => settings.get_string('access-token') !== '';
+
+        // Status row
+        const statusRow = new Adw.ActionRow({
+            title: 'Status',
+        });
+        const statusLabel = new Gtk.Label({
+            valign: Gtk.Align.CENTER,
+        });
+        statusRow.add_suffix(statusLabel);
+        authGroup.add(statusRow);
+
+        const updateStatus = (msg, connected) => {
+            statusLabel.set_label(msg);
+            if (connected) {
+                statusLabel.set_css_classes(['success']);
+            } else {
+                statusLabel.set_css_classes(['dim-label']);
+            }
+        };
+
+        // Connect button row
+        const connectRow = new Adw.ActionRow({
+            title: 'Connect Claude Account',
+            subtitle: 'Opens your browser to authorize the extension',
+        });
+        const connectButton = new Gtk.Button({
+            label: 'Connect',
+            valign: Gtk.Align.CENTER,
+            css_classes: ['suggested-action'],
+        });
+        connectRow.add_suffix(connectButton);
+        connectRow.set_activatable_widget(connectButton);
+        authGroup.add(connectRow);
+
+        // Code entry row (hidden until Connect is clicked)
+        const codeRow = new Adw.EntryRow({
+            title: 'Code from browser',
+            show_apply_button: true,
+        });
+        codeRow.set_visible(false);
+        authGroup.add(codeRow);
+
+        // Disconnect row (only shown when connected)
+        const disconnectRow = new Adw.ActionRow({
+            title: 'Disconnect',
+            subtitle: 'Remove stored credentials',
+        });
+        const disconnectButton = new Gtk.Button({
+            label: 'Disconnect',
+            valign: Gtk.Align.CENTER,
+            css_classes: ['destructive-action'],
+        });
+        disconnectRow.add_suffix(disconnectButton);
+        disconnectRow.set_activatable_widget(disconnectButton);
+        disconnectRow.set_visible(isConnected());
+        authGroup.add(disconnectRow);
+
+        // Set initial status
+        if (isConnected()) {
+            updateStatus('Connected', true);
+        } else {
+            updateStatus('Not connected', false);
+        }
+
+        // State for PKCE flow
+        let codeVerifier = null;
+        let oauthState = null;
+
+        // Connect button handler
+        connectButton.connect('clicked', () => {
+            codeVerifier = generateCodeVerifier();
+            const challenge = codeChallenge(codeVerifier);
+            oauthState = generateCodeVerifier(); // reuse for random state
+            const state = oauthState;
+
+            const params = [
+                `response_type=code`,
+                `client_id=${encodeURIComponent(CLIENT_ID)}`,
+                `redirect_uri=${encodeURIComponent(REDIRECT_URI)}`,
+                `scope=${encodeURIComponent(OAUTH_SCOPES)}`,
+                `code_challenge=${encodeURIComponent(challenge)}`,
+                `code_challenge_method=S256`,
+                `state=${encodeURIComponent(state)}`,
+            ].join('&');
+
+            const url = `${AUTHORIZE_URL}?${params}`;
+            Gio.AppInfo.launch_default_for_uri(url, null);
+            codeRow.set_visible(true);
+            codeRow.set_text('');
+            updateStatus('Waiting for code…', false);
+        });
+
+        // Submit handler (apply button on codeRow)
+        codeRow.connect('apply', () => {
+            if (!codeVerifier) {
+                updateStatus('Click Connect first', false);
+                return;
+            }
+
+            let input = codeRow.get_text().trim();
+            let code = input;
+            let extractedState = oauthState;
+
+            // If user pasted a full URL, extract code and state from it
+            try {
+                const url = new URL(input);
+                if (url.searchParams.has('code'))
+                    code = url.searchParams.get('code');
+                if (url.searchParams.has('state'))
+                    extractedState = url.searchParams.get('state');
+            } catch (_) {
+                // Not a URL — treat as raw code, strip any #fragment
+                const hashIdx = code.indexOf('#');
+                if (hashIdx !== -1)
+                    code = code.slice(0, hashIdx);
+            }
+
+            if (!code) {
+                updateStatus('Code cannot be empty', false);
+                return;
+            }
+
+            updateStatus('Exchanging code…', false);
+            connectButton.set_sensitive(false);
+
+            const body = JSON.stringify({
+                grant_type: 'authorization_code',
+                code,
+                state: extractedState,
+                client_id: CLIENT_ID,
+                redirect_uri: REDIRECT_URI,
+                code_verifier: codeVerifier,
+            });
+
+            const session = new Soup.Session();
+            const message = Soup.Message.new('POST', TOKEN_URL);
+            message.request_headers.append('Content-Type', 'application/json');
+            message.set_request_body_from_bytes(
+                null,
+                new GLib.Bytes(new TextEncoder().encode(body))
+            );
+
+            session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null, (_session, result) => {
+                try {
+                    const bytes = _session.send_and_read_finish(result);
+                    if (message.status_code !== 200) {
+                        const errText = new TextDecoder().decode(bytes.get_data());
+                        console.error('Claude Usage prefs: Token exchange failed:', errText);
+                        updateStatus(`Error ${message.status_code}`, false);
+                        connectButton.set_sensitive(true);
+                        return;
+                    }
+                    const resp = JSON.parse(new TextDecoder().decode(bytes.get_data()));
+                    settings.set_string('access-token', resp.access_token);
+                    settings.set_string('refresh-token', resp.refresh_token);
+                    settings.set_int64('expires-at', Date.now() + (resp.expires_in ?? 28800) * 1000);
+                    updateStatus('Connected', true);
+                    codeRow.set_visible(false);
+                    disconnectRow.set_visible(true);
+                    codeVerifier = null;
+                    oauthState = null;
+                } catch (e) {
+                    console.error('Claude Usage prefs: Token exchange error:', e.message);
+                    updateStatus('Exchange failed', false);
+                } finally {
+                    connectButton.set_sensitive(true);
+                }
+            });
+        });
+
+        // Disconnect handler
+        disconnectButton.connect('clicked', () => {
+            settings.set_string('access-token', '');
+            settings.set_string('refresh-token', '');
+            settings.set_int64('expires-at', 0);
+            updateStatus('Not connected', false);
+            disconnectRow.set_visible(false);
+            codeRow.set_visible(false);
+            codeVerifier = null;
+            oauthState = null;
+        });
     }
 }

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -26,5 +26,20 @@
       <summary>Proxy URL</summary>
       <description>HTTP proxy URL (e.g., http://localhost:11809). Leave empty to use no proxy.</description>
     </key>
+    <key name="access-token" type="s">
+      <default>''</default>
+      <summary>OAuth access token</summary>
+      <description>Extension's own OAuth access token obtained via PKCE flow.</description>
+    </key>
+    <key name="refresh-token" type="s">
+      <default>''</default>
+      <summary>OAuth refresh token</summary>
+      <description>Extension's own OAuth refresh token for renewing the access token.</description>
+    </key>
+    <key name="expires-at" type="x">
+      <default>0</default>
+      <summary>Token expiry timestamp</summary>
+      <description>Millisecond timestamp when the access token expires.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Workaround for https://github.com/Haletran/claude-usage-extension/issues/3

<img width="693" height="313" alt="image" src="https://github.com/user-attachments/assets/191f10eb-34fc-4464-a294-6c074a170af8" />

## Summary

This has proven extremely reliable in my testing. Occasionally from resuming from sleep it will show an error, but always reconnects on the next attempt and updates.

- Adds an **Authentication** group to the preferences window with a
  full PKCE OAuth flow: click Connect → browser opens → paste the code
  from the callback page → tokens are stored in GSettings
- The extension now manages its own access/refresh token and no longer
  requires Claude Code CLI to be installed or logged in
- Falls back to reading `~/.claude/.credentials.json` for users who
  don't use the in-extension auth
- Token is automatically refreshed 5 minutes before expiry
- Rate-limited (429) responses are silently ignored — the panel keeps
  showing the last known data rather than flashing an error
- An in-flight guard prevents overlapping requests if the network is
  slow and the timer fires before the previous request completes

## Implementation notes

- Token endpoint: `https://api.anthropic.com/v1/oauth/token` (avoids
  Cloudflare challenge on the `console.anthropic.com` equivalent)
- Token exchange body must be JSON (not form-urlencoded), and `state`
  must be included — both required by Anthropic's server
- Uses the Claude Code CLI's public client ID
  (`9d1c250a-e61b-44d9-88ed-5944d1962f5e`) since there is no separate
  registration for third-party extensions

## Test plan

- [x] Fresh install: Connect flow opens browser, code exchange succeeds,
      usage data appears in panel
- [x] Token refresh: wait for token to near expiry (or manually set
      `expires-at` to a past value) and confirm it auto-refreshes
- [x] Fallback: Disconnect, confirm extension falls back to
      `~/.claude/.credentials.json`
- [x] Disconnect: clears stored tokens, status shows "Not connected"
- [x] Rate limiting: confirm panel keeps last data on 429 (no error shown)

