### PR TITLE
fix: change all text colors to black

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -40,7 +40,7 @@
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #000000;
+    color: #ffffff;
 }
 
 /* Progress bar styles */
@@ -90,7 +90,7 @@
     padding: 4px 12px;
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.1);
-    color: #000000;
+    color: #ffffff;
     font-size: 12px;
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -34,13 +34,13 @@
 .claude-section-title {
     font-size: 13px;
     font-weight: 600;
-    color: #e0e0e0;
+    color: #000000;
 }
 
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #ffffff;
+    color: #000000;
 }
 
 /* Progress bar styles */
@@ -77,7 +77,7 @@
 /* Reset label styles */
 .claude-reset-label {
     font-size: 11px;
-    color: #a0a0a0;
+    color: #000000;
 }
 
 /* Footer styles */
@@ -90,7 +90,7 @@
     padding: 4px 12px;
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.1);
-    color: #ffffff;
+    color: #000000;
     font-size: 12px;
 }
 
@@ -105,5 +105,5 @@
 .claude-last-updated-label {
     font-size: 10px;
     font-style: italic;
-    color: #808080;
+    color: #000000;
 }


### PR DESCRIPTION
## Summary
- Changed all text colors in `stylesheet.css` to `#000000` (black)
- Affected classes: `.claude-section-title`, `.claude-percent-label`, `.claude-reset-label`, `.claude-refresh-button`, `.claude-last-updated-label`

## Test plan
- [ ] Enable the extension and open the dropdown menu
- [ ] Verify all text (section titles, percentages, reset labels) renders in black

🤖 Generated with [Claude Code](https://claude.com/claude-code)