### PR TITLE
Change popup menu text color to black

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,12 +32,10 @@
 
 .claude-section-title {
     font-weight: 600;
-    color: #000000;
 }
 
 .claude-percent-label {
     font-weight: bold;
-    color: #000000;
 }
 
 /* Progress bar styles */
@@ -71,10 +69,7 @@
     background-color: #ef4444;
 }
 
-/* Reset label styles */
-.claude-reset-label {
-    color: #000000;
-}
+
 
 /* Footer styles */
 .claude-footer-box {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4,7 +4,6 @@
 }
 
 .claude-usage-label {
-    font-size: 12px;
     font-weight: bold;
 }
 
@@ -32,13 +31,11 @@
 }
 
 .claude-section-title {
-    font-size: 13px;
     font-weight: 600;
     color: #000000;
 }
 
 .claude-percent-label {
-    font-size: 13px;
     font-weight: bold;
     color: #000000;
 }
@@ -76,7 +73,6 @@
 
 /* Reset label styles */
 .claude-reset-label {
-    font-size: 11px;
     color: #000000;
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -34,13 +34,13 @@
 .claude-section-title {
     font-size: 13px;
     font-weight: 600;
-    color: #e0e0e0;
+    color: #000000;
 }
 
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #ffffff;
+    color: #000000;
 }
 
 /* Progress bar styles */
@@ -77,7 +77,7 @@
 /* Reset label styles */
 .claude-reset-label {
     font-size: 11px;
-    color: #a0a0a0;
+    color: #000000;
 }
 
 /* Footer styles */
@@ -90,7 +90,7 @@
     padding: 4px 12px;
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.1);
-    color: #ffffff;
+    color: #000000;
     font-size: 12px;
 }
 
@@ -105,5 +105,5 @@
 .claude-last-updated-label {
     font-size: 10px;
     font-style: italic;
-    color: #808080;
+    color: #000000;
 }


### PR DESCRIPTION
## Summary
- Keep top bar text color unchanged (inherits white from shell theme)
- Change all popup/dropdown text colors to black (`#000000`) for better readability:
  - Section titles (`.claude-section-title`: `#e0e0e0` → `#000000`)
  - Percentage labels (`.claude-percent-label`: `#ffffff` → `#000000`)
  - Reset labels (`.claude-reset-label`: `#a0a0a0` → `#000000`)
  - Refresh button (`.claude-refresh-button`: `#ffffff` → `#000000`)
  - Last updated label (`.claude-last-updated-label`: `#808080` → `#000000`)