### PR TITLE
Use theme-neutral colors for light theme compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -133,7 +133,7 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         if (style === 'monochrome' && !hasEffect) {
             this._icon.add_effect(new Clutter.DesaturateEffect({factor: 1.0, name: desatName}));
             const brightnessEffect = new Clutter.BrightnessContrastEffect({name: brightName});
-            brightnessEffect.set_brightness_full(1, 1, 1);
+            brightnessEffect.set_brightness_full(0.6, 0.6, 0.6);
             this._icon.add_effect(brightnessEffect);
         } else if (style !== 'monochrome' && hasEffect) {
             this._icon.remove_effect_by_name(desatName);

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -10,7 +10,7 @@
 
 /* Panel progress bar */
 .claude-panel-progress-bg {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(128, 128, 128, 0.3);
     border-radius: 3px;
     height: 10px;
     width: 50px;
@@ -21,7 +21,7 @@
     height: 10px;
     border-radius: 3px;
     transition: width 300ms ease-out;
-    background-color: #ffffff;
+    background-color: rgba(128, 128, 128, 0.8);
 }
 
 /* Usage section styles */
@@ -34,18 +34,16 @@
 .claude-section-title {
     font-size: 13px;
     font-weight: 600;
-    color: #e0e0e0;
 }
 
 .claude-percent-label {
     font-size: 13px;
     font-weight: bold;
-    color: #ffffff;
 }
 
 /* Progress bar styles */
 .claude-progress-bg {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(128, 128, 128, 0.2);
     border-radius: 4px;
     height: 8px;
     width: 200px;
@@ -77,7 +75,7 @@
 /* Reset label styles */
 .claude-reset-label {
     font-size: 11px;
-    color: #a0a0a0;
+    color: rgba(128, 128, 128, 0.8);
 }
 
 /* Footer styles */
@@ -89,21 +87,20 @@
 .claude-refresh-button {
     padding: 4px 12px;
     border-radius: 4px;
-    background-color: rgba(255, 255, 255, 0.1);
-    color: #ffffff;
+    background-color: rgba(128, 128, 128, 0.2);
     font-size: 12px;
 }
 
 .claude-refresh-button:hover {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(128, 128, 128, 0.3);
 }
 
 .claude-refresh-button:active {
-    background-color: rgba(255, 255, 255, 0.15);
+    background-color: rgba(128, 128, 128, 0.25);
 }
 
 .claude-last-updated-label {
     font-size: 10px;
     font-style: italic;
-    color: #808080;
+    color: rgba(128, 128, 128, 0.7);
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded white colors (`#ffffff`, `rgba(255,255,255,...)`, `#e0e0e0`) with neutral grays (`rgba(128,128,128,...)`) in `stylesheet.css`
- Remove hardcoded text colors on `.claude-section-title` and `.claude-percent-label` so they inherit from the GNOME Shell theme
- Reduce monochrome icon brightness from `1.0` to `0.6` to prevent the icon from being washed out on light backgrounds

## Why

The current styles use white/light colors that are designed for dark GNOME Shell themes. On light themes, elements like the panel progress bar and text labels become invisible or hard to read. Using neutral gray tones with alpha transparency works well on both dark and light themes.

## Test plan

- [ ] Verify extension looks correct on a dark GNOME Shell theme (e.g. Adwaita Dark)
- [ ] Verify extension looks correct on a light GNOME Shell theme (e.g. Adwaita Light)
- [ ] Verify monochrome icon is visible on both dark and light panels

🤖 Generated with [Claude Code](https://claude.ai/code)