### PR TITLE
feat: add GNOME 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Claude Code Usage",
   "description": "Display Claude Code usage in the top panel. This extension uses anthropic.com services. This extension is not affiliated, funded, or in any way associated with Claude.",
   "uuid": "claude-code-usage@haletran.com",
-  "shell-version": ["46", "47", "48", "49"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "url": "https://github.com/Haletran/claude-usage-extension",
   "settings-schema": "org.gnome.shell.extensions.claude-code-usage",
   "donations": {


### PR DESCRIPTION
## Summary
- Added `"50"` to `shell-version` in `metadata.json` to declare compatibility with GNOME Shell 50