### PR TITLE
feat: add per-model 7-day usage breakdown in popup menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A GNOME Shell extension that displays your Claude Code API usage percentage in t
 ## Features                                                                                                                                                                                                      
                                                                                                                                                                                                                    
 - **Real-time usage monitoring** - View your 5-hour and 7-day Claude Code usage                                                                                                                                  
+- **Per-model weekly limits** - Optionally show 7-day usage broken down per model (e.g. Opus, Sonnet) when exposed by the API. Toggle in settings.
 - **Settings menu*** - Change the layout or the refresh time                                                                                                                                              
                                                                                                                                                                                                             
 ## Requirements                                                                                                                                                                                                  

--- a/extension.js
+++ b/extension.js
@@ -13,6 +13,22 @@ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/ex
 
 const API_URL = 'https://api.anthropic.com/api/oauth/usage';
 
+const PER_MODEL_LABEL_MAP = {
+    opus: 'Opus',
+    sonnet: 'Sonnet',
+    haiku: 'Haiku',
+    oauth_apps: 'OAuth Apps',
+};
+
+function _formatPerModelLabel(suffix) {
+    if (PER_MODEL_LABEL_MAP[suffix])
+        return PER_MODEL_LABEL_MAP[suffix];
+    return suffix
+        .split('_')
+        .map(w => w.length === 0 ? w : w[0].toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
 const ClaudeUsageIndicator = GObject.registerClass(
 class ClaudeUsageIndicator extends PanelMenu.Button {
     _init(extensionPath, settings, openPreferences) {
@@ -72,6 +88,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 this._recreateSession();
             } else if (key === 'icon-style') {
                 this._updateIconStyle();
+            } else if (key === 'show-per-model-weekly') {
+                this._updatePerModelVisibility();
             }
         });
 
@@ -226,6 +244,23 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
         sevenDayItem.add_child(sevenDayBox);
         this.menu.addMenuItem(sevenDayItem);
 
+        this._perModelSeparator = new PopupMenu.PopupSeparatorMenuItem();
+        this.menu.addMenuItem(this._perModelSeparator);
+
+        this._perModelContainer = new St.BoxLayout({
+            style_class: 'claude-per-model-container',
+            vertical: true,
+        });
+        this._perModelMenuItem = new PopupMenu.PopupBaseMenuItem({
+            reactive: false,
+            can_focus: false,
+        });
+        this._perModelMenuItem.add_child(this._perModelContainer);
+        this.menu.addMenuItem(this._perModelMenuItem);
+
+        this._perModelMenuItem.visible = false;
+        this._perModelSeparator.visible = false;
+
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         const settingsItem = new PopupMenu.PopupMenuItem('Settings');
@@ -348,6 +383,66 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
                 `Resets in ${this._formatResetTime(data.seven_day.resets_at)}`
             );
         }
+
+        this._renderPerModelSections(data);
+    }
+
+    _renderPerModelSections(data) {
+        this._perModelEntries = Object.keys(data)
+            .filter(k => k.startsWith('seven_day_') && k !== 'seven_day' && data[k] !== null)
+            .map(k => ({suffix: k.replace(/^seven_day_/, ''), entry: data[k]}));
+
+        this._perModelContainer.destroy_all_children();
+
+        this._perModelEntries.forEach(({suffix, entry}, idx) => {
+            const sectionBox = new St.BoxLayout({
+                style_class: 'claude-usage-section',
+                vertical: true,
+            });
+            if (idx > 0)
+                sectionBox.set_style('margin-top: 8px;');
+
+            const header = new St.BoxLayout({vertical: false});
+            const titleLabel = new St.Label({
+                text: `${_formatPerModelLabel(suffix)} (7-Day)`,
+                style_class: 'claude-section-title',
+            });
+            header.add_child(titleLabel);
+            const percentLabel = new St.Label({
+                text: `${(entry.utilization ?? 0).toFixed(1)}%`,
+                style_class: 'claude-percent-label',
+                x_expand: true,
+                x_align: Clutter.ActorAlign.END,
+            });
+            header.add_child(percentLabel);
+            sectionBox.add_child(header);
+
+            const progressBg = new St.Widget({style_class: 'claude-progress-bg'});
+            const progressBar = new St.Widget({style_class: 'claude-progress-bar'});
+            progressBg.add_child(progressBar);
+            sectionBox.add_child(progressBg);
+            this._updateProgressBar(progressBar, entry.utilization ?? 0);
+
+            const resetLabel = new St.Label({
+                text: entry.resets_at
+                    ? `Resets in ${this._formatResetTime(entry.resets_at)}`
+                    : 'Not used yet',
+                style_class: 'claude-reset-label',
+            });
+            sectionBox.add_child(resetLabel);
+
+            this._perModelContainer.add_child(sectionBox);
+        });
+
+        this._updatePerModelVisibility();
+    }
+
+    _updatePerModelVisibility() {
+        const showSetting = this._settings.get_boolean('show-per-model-weekly');
+        const hasEntries = this._perModelEntries && this._perModelEntries.length > 0;
+        const visible = showSetting && hasEntries;
+        this._perModelMenuItem.visible = visible;
+        this._perModelSeparator.visible = visible;
     }
 
     _updatePanelProgressBar(usage) {

--- a/extension.js
+++ b/extension.js
@@ -18,6 +18,7 @@ const PER_MODEL_LABEL_MAP = {
     sonnet: 'Sonnet',
     haiku: 'Haiku',
     oauth_apps: 'OAuth Apps',
+    omelette: 'Claude Design',
 };
 
 function _formatPerModelLabel(suffix) {

--- a/prefs.js
+++ b/prefs.js
@@ -100,6 +100,24 @@ export default class ClaudeUsagePreferences extends ExtensionPreferences {
         );
         displayGroup.add(showIconRow);
 
+        const menuGroup = new Adw.PreferencesGroup({
+            title: 'Menu Display',
+            description: 'Configure the popup menu shown when clicking the indicator',
+        });
+        page.add(menuGroup);
+
+        const showPerModelRow = new Adw.SwitchRow({
+            title: 'Show Per-Model Weekly Limits',
+            subtitle: 'Show extra 7-day usage sections for each model exposed by the API (e.g. Opus, Sonnet)',
+        });
+        settings.bind(
+            'show-per-model-weekly',
+            showPerModelRow,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        menuGroup.add(showPerModelRow);
+
         const networkGroup = new Adw.PreferencesGroup({
             title: 'Network',
             description: 'Configure network settings',

--- a/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.claude-code-usage.gschema.xml
@@ -26,5 +26,10 @@
       <summary>Proxy URL</summary>
       <description>HTTP proxy URL (e.g., http://localhost:11809). Leave empty to use no proxy.</description>
     </key>
+    <key name="show-per-model-weekly" type="b">
+      <default>true</default>
+      <summary>Show per-model weekly usage</summary>
+      <description>Whether to show per-model 7-day usage sections (e.g. Opus, Sonnet) in the popup menu, when the API exposes them.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
## Summary

Adds optional per-model 7-day usage sections to the popup menu, in addition to the existing global 5-hour and 7-day windows.

The Anthropic OAuth `/api/oauth/usage` endpoint exposes per-model 7-day windows alongside the global ones (`seven_day_opus`, `seven_day_sonnet`, `seven_day_oauth_apps`, etc.). This PR auto-discovers any  
 `seven_day_<name>` keys in the API response and renders one section per non-null entry, so the menu reflects exactly what the user's plan exposes — no schema churn needed if Anthropic adds new model-specific
quotas later.

## What's new

- **Auto-discovered per-model sections** — for every non-null `seven_day_<name>` field, render a section with title, percentage, progress bar, and reset time
- **Friendly labels for known suffixes** (`opus` → "Opus", `sonnet` → "Sonnet", `haiku` → "Haiku", `oauth_apps` → "OAuth Apps") with a titlecased fallback for anything else
- **`show-per-model-weekly` setting** (default: on) controlling visibility of the whole block
- **New "Menu Display" preferences group** containing the toggle
- The block hides itself silently when the API returns no per-model data (e.g. Pro plan), so there's no visual noise for users who don't have these quotas  


## Screenshots

<img width="498" height="423" alt="claude-usage-feature" src="https://github.com/user-attachments/assets/b8104002-d973-45c9-a1cf-27da5a49f374" />

## Test plan

- [x] Tested on Fedora 43 + GNOME Shell on Wayland (Max plan)
- [x] Verified API response shape with `curl` against `/api/oauth/usage`
- [x] Verified popup menu shows new sections after relogging
- [x] Verified toggling `show-per-model-weekly` in settings hides/shows the block live
- [x] Verified `null` entries are filtered (Opus / OAuth Apps / Cowork hidden when not on those quotas)
- [x] Verified `{utilization: 0, resets_at: null}` entries render as "0.0%" / "Not used yet"  


## Notes

- No new CSS — reuses existing `claude-usage-section`, `claude-section-title`, `claude-percent-label`, `claude-progress-bg`, `claude-progress-bar`, `claude-reset-label` style classes
- No new dependency
- Schema gettext-domain unchanged
- Compatible with the existing GNOME Shell version range declared in `metadata.json` (46–49)  