### PR TITLE
fix: GNOME 50 compatibility with Libsoup 3 API

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -294,8 +294,8 @@ class ClaudeUsageIndicator extends PanelMenu.Button {
 
     _fetchUsage(token) {
         const message = Soup.Message.new('GET', API_URL);
-        message.request_headers.append('Authorization', `Bearer ${token}`);
-        message.request_headers.append('anthropic-beta', 'oauth-2025-04-20');
+        message.get_request_headers().append('Authorization', `Bearer ${token}`);
+        message.get_request_headers().append('anthropic-beta', 'oauth-2025-04-20');
 
         this._session.send_and_read_async(
             message,

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Claude Code Usage",
   "description": "Display Claude Code usage in the top panel. This extension uses anthropic.com services. This extension is not affiliated, funded, or in any way associated with Claude.",
   "uuid": "claude-code-usage@haletran.com",
-  "shell-version": ["46", "47", "48", "49"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "url": "https://github.com/Haletran/claude-usage-extension",
   "settings-schema": "org.gnome.shell.extensions.claude-code-usage",
   "donations": {

--- a/prefs.js
+++ b/prefs.js
@@ -2,7 +2,7 @@ import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
 import Gio from 'gi://Gio';
 
-import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences} from 'resource:///org/gnome/shell/extensions/prefs.js';
 
 export default class ClaudeUsagePreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {

--- a/prefs.js
+++ b/prefs.js
@@ -2,7 +2,7 @@ import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
 import Gio from 'gi://Gio';
 
-import {ExtensionPreferences} from 'resource:///org/gnome/shell/extensions/prefs.js';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class ClaudeUsagePreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {


### PR DESCRIPTION
## Summary

- Add `"50"` to `shell-version` in `metadata.json` so the extension loads on GNOME Shell 50
- Replace `message.request_headers.append()` with `message.get_request_headers().append()` — the direct property access crashes on Libsoup 3 (used in GNOME 45+)
- Fix `prefs.js` import path: `resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js` → `resource:///org/gnome/shell/extensions/prefs.js` (case-sensitive path fix for GNOME 45+ module resolution)

## Test

Tested on GNOME Shell 50.1 — extension loads, usage data displays correctly, settings window opens without errors.

Closes #27, #19